### PR TITLE
Generating metrics from the flink jobs

### DIFF
--- a/activity-aggregate-updater/src/main/scala/org/sunbird/job/functions/ActivityAggregatesFunction.scala
+++ b/activity-aggregate-updater/src/main/scala/org/sunbird/job/functions/ActivityAggregatesFunction.scala
@@ -110,7 +110,12 @@ class ActivityAggregatesFunction(config: ActivityAggregateUpdaterConfig)(implici
     val courseId = userConsumption.courseId
     val userId = userConsumption.userId
     val contextId = "cb:" + userConsumption.batchId
-    val leafNodes = readFromCache(key = s"$courseId:$courseId:${config.leafNodes}", metrics).distinct
+    val key = s"$courseId:$courseId:${config.leafNodes}"
+    val leafNodes = readFromCache(key, metrics).distinct
+    if (leafNodes.isEmpty) {
+      metrics.incCounter(config.failedEventCount)
+      throw new Exception(s"leaf nodes are not available: $key")
+    }
     val completedCount = leafNodes.intersect(userConsumption.contents.filter(cc => cc._2.status == 2).map(cc => cc._2.contentId).toList.distinct).size
     UserActivityAgg("Course", userId, courseId, contextId, Map("completedCount" -> completedCount), Map("completedCount" -> System.currentTimeMillis()))
   }

--- a/relation-cache-updater/src/main/scala/org/sunbird/job/functions/RelationCacheUpdater.scala
+++ b/relation-cache-updater/src/main/scala/org/sunbird/job/functions/RelationCacheUpdater.scala
@@ -76,7 +76,7 @@ class RelationCacheUpdater(config: RelationCacheUpdaterConfig)
     }
 
     override def metricsList(): List[String] = {
-        List(config.successEventCount, config.failedEventCount, config.skippedEventCount, config.totalEventsCount, config.dbReadCount, config.cacheHit)
+        List(config.successEventCount, config.failedEventCount, config.skippedEventCount, config.totalEventsCount, config.dbReadCount, config.cacheWrite)
     }
 
     private def isValidEvent(eData: java.util.Map[String, AnyRef]): Boolean = {
@@ -162,10 +162,10 @@ class RelationCacheUpdater(config: RelationCacheUpdaterConfig)
             dataMap.foreach(each => each._2 match {
                 case value: List[String] =>
                     cache.addListWithRetry(finalPrefix + each._1 + finalSuffix, each._2.asInstanceOf[List[String]])
-                    metrics.incCounter(config.cacheHit)
+                    metrics.incCounter(config.cacheWrite)
                 case _ =>
                     cache.setWithRetry(finalPrefix + each._1 + finalSuffix, each._2.asInstanceOf[String])
-                    metrics.incCounter(config.cacheHit)
+                    metrics.incCounter(config.cacheWrite)
             })
         } catch {
             case e: Throwable => {

--- a/relation-cache-updater/src/main/scala/org/sunbird/job/task/RelationCacheUpdaterConfig.scala
+++ b/relation-cache-updater/src/main/scala/org/sunbird/job/task/RelationCacheUpdaterConfig.scala
@@ -23,6 +23,8 @@ class RelationCacheUpdaterConfig(override val config: Config) extends BaseJobCon
   val successEventCount = "success-events-count"
   val failedEventCount = "failed-events-count"
   val skippedEventCount = "skipped-event-count"
+  val cacheHit = "cache-hit-count"
+  val dbReadCount = "db-read-count"
 
   // Consumers
   val relationCacheConsumer = "relation-cache-updater-consumer"

--- a/relation-cache-updater/src/main/scala/org/sunbird/job/task/RelationCacheUpdaterConfig.scala
+++ b/relation-cache-updater/src/main/scala/org/sunbird/job/task/RelationCacheUpdaterConfig.scala
@@ -23,7 +23,7 @@ class RelationCacheUpdaterConfig(override val config: Config) extends BaseJobCon
   val successEventCount = "success-events-count"
   val failedEventCount = "failed-events-count"
   val skippedEventCount = "skipped-event-count"
-  val cacheHit = "cache-hit-count"
+  val cacheWrite = "cache-write-count"
   val dbReadCount = "db-read-count"
 
   // Consumers

--- a/relation-cache-updater/src/test/scala/org/sunbird/job/spec/RelationCacheUpdaterTaskTestSpec.scala
+++ b/relation-cache-updater/src/test/scala/org/sunbird/job/spec/RelationCacheUpdaterTaskTestSpec.scala
@@ -89,7 +89,7 @@ class RelationCacheUpdaterTaskTestSpec extends BaseTestSpec {
     BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.failedEventCount}").getValue() should be(0)
     BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.skippedEventCount}").getValue() should be(0)
     BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.dbReadCount}").getValue() should be(2)
-    BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.cacheHit}").getValue() should be(43)
+    BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.cacheWrite}").getValue() should be(43)
 
     // Assertion on total keys for leafnodes and ancestors.
     getKeysLength("*:leafnodes", relCacheDb) should be (18)

--- a/relation-cache-updater/src/test/scala/org/sunbird/job/spec/RelationCacheUpdaterTaskTestSpec.scala
+++ b/relation-cache-updater/src/test/scala/org/sunbird/job/spec/RelationCacheUpdaterTaskTestSpec.scala
@@ -88,6 +88,8 @@ class RelationCacheUpdaterTaskTestSpec extends BaseTestSpec {
     BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.successEventCount}").getValue() should be(2)
     BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.failedEventCount}").getValue() should be(0)
     BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.skippedEventCount}").getValue() should be(0)
+    BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.dbReadCount}").getValue() should be(2)
+    BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.cacheHit}").getValue() should be(43)
 
     // Assertion on total keys for leafnodes and ancestors.
     getKeysLength("*:leafnodes", relCacheDb) should be (18)


### PR DESCRIPTION
1) Activity Agg Updater: Stopping the Flink job when the course leaf nodes are empty and generating the failed events metrics count
2) UserCacheUpdater: Generating db_read, cache_hit metrics 
