### PR TITLE
createListWithRetry - method in DataCache

### DIFF
--- a/jobs-core/src/main/scala/org/sunbird/job/cache/DataCache.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/cache/DataCache.scala
@@ -103,6 +103,33 @@ class DataCache(val config: BaseJobConfig, val redisConnect: RedisConnect, val d
     }
   }
 
+  /**
+   * The cache will be created by clearing the existing data from smembers.
+   * @param key
+   * @param value
+   */
+  def createListWithRetry(key: String, value: List[String]): Unit = {
+    try {
+      redisConnection.del(key)
+      redisConnection.sadd(key, value.map(_.asInstanceOf[String]): _*)
+    } catch {
+      // Write testcase for catch block
+      // $COVERAGE-OFF$ Disabling scoverage
+      case ex: JedisException => {
+        logger.error("Exception when inserting data to redis cache", ex)
+        this.redisConnection.close()
+        this.redisConnection = redisConnect.getConnection(dbIndex)
+        redisConnection.del(key)
+        redisConnection.sadd(key, value.map(_.asInstanceOf[String]): _*)
+      }
+    }
+  }
+
+  /**
+   * The cache will add the given members if already exists otherwise, it will create cache with the given members.
+   * @param key
+   * @param value
+   */
   def addListWithRetry(key: String, value: List[String]): Unit = {
     try {
       redisConnection.sadd(key, value.map(_.asInstanceOf[String]): _*)
@@ -110,7 +137,6 @@ class DataCache(val config: BaseJobConfig, val redisConnect: RedisConnect, val d
       // Write testcase for catch block
       // $COVERAGE-OFF$ Disabling scoverage
       case ex: JedisException => {
-        println("dataCache")
         logger.error("Exception when inserting data to redis cache", ex)
         this.redisConnection.close()
         this.redisConnection = redisConnect.getConnection(dbIndex)

--- a/relation-cache-updater/src/main/scala/org/sunbird/job/functions/RelationCacheUpdater.scala
+++ b/relation-cache-updater/src/main/scala/org/sunbird/job/functions/RelationCacheUpdater.scala
@@ -161,7 +161,7 @@ class RelationCacheUpdater(config: RelationCacheUpdaterConfig)
         try {
             dataMap.foreach(each => each._2 match {
                 case value: List[String] =>
-                    cache.addListWithRetry(finalPrefix + each._1 + finalSuffix, each._2.asInstanceOf[List[String]])
+                    cache.createListWithRetry(finalPrefix + each._1 + finalSuffix, each._2.asInstanceOf[List[String]])
                     metrics.incCounter(config.cacheWrite)
                 case _ =>
                     cache.setWithRetry(finalPrefix + each._1 + finalSuffix, each._2.asInstanceOf[String])


### PR DESCRIPTION
In Relation-Cache-Updater,
while updating the cache, it is always appending the data to the existing list. Due to this, if a collection is republished by removing and adding some contents, it is not reflecting the final leafnodes cache properly.