### PR TITLE
Checkpointing changes - compressed and pause between

### DIFF
--- a/jobs-core/src/main/resources/base-config.conf
+++ b/jobs-core/src/main/resources/base-config.conf
@@ -18,6 +18,8 @@ job {
 }
 
 task {
+  checkpointing.compressed = true
+  checkpointing.pause.between.seconds = 30000
   parallelism = 1
   checkpointing.interval = 60000
   restart-strategy.attempts = 3

--- a/jobs-core/src/main/scala/org/sunbird/job/BaseJobConfig.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/BaseJobConfig.scala
@@ -25,7 +25,9 @@ class BaseJobConfig(val config: Config, val jobName: String) extends Serializabl
   val kafkaAutoOffsetReset: Option[String] = if (config.hasPath("kafka.auto.offset.reset")) Option(config.getString("kafka.auto.offset.reset")) else None
 
   // Checkpointing config
+  val enableCompressedCheckpointing: Boolean = config.getBoolean("task.checkpointing.compressed")
   val checkpointingInterval: Int = config.getInt("task.checkpointing.interval")
+  val checkpointingPauseSeconds: Int = config.getInt("task.checkpointing.pause.between.seconds")
   val enableDistributedCheckpointing: Option[Boolean] = if (config.hasPath("job")) Option(config.getBoolean("job.enable.distributed.checkpointing")) else None
   val checkpointingBaseUrl: Option[String] = if (config.hasPath("job")) Option(config.getString("job.statebackend.base.url")) else None
 

--- a/jobs-core/src/main/scala/org/sunbird/job/util/FlinkUtil.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/FlinkUtil.scala
@@ -12,6 +12,7 @@ object FlinkUtil {
 
   def getExecutionContext(config: BaseJobConfig): StreamExecutionEnvironment = {
     val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    env.getConfig.setUseSnapshotCompression(config.enableCompressedCheckpointing)
     env.enableCheckpointing(config.checkpointingInterval)
 
     /**
@@ -24,6 +25,7 @@ object FlinkUtil {
         env.setStateBackend(stateBackend)
         val checkpointConfig: CheckpointConfig = env.getCheckpointConfig
         checkpointConfig.enableExternalizedCheckpoints(ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION)
+        checkpointConfig.setMinPauseBetweenCheckpoints(config.checkpointingPauseSeconds)
       }
       case _ => // Do nothing
     }

--- a/jobs-core/src/test/resources/base-test.conf
+++ b/jobs-core/src/test/resources/base-test.conf
@@ -13,6 +13,8 @@ kafka {
 }
 
 task {
+  checkpointing.compressed = true
+  checkpointing.pause.between.seconds = 30000
   checkpointing.interval = 60000
   restart-strategy.attempts = 1
   restart-strategy.delay = 10000

--- a/jobs-core/src/test/scala/org/sunbird/fixture/EventFixture.scala
+++ b/jobs-core/src/test/scala/org/sunbird/fixture/EventFixture.scala
@@ -44,6 +44,8 @@ object EventFixture {
       |task {
       |  parallelism = 2
       |  consumer.parallelism = 1
+      |  checkpointing.compressed = true
+      |  checkpointing.pause.between.seconds = 30000
       |  checkpointing.interval = 60000
       |  metrics.window.size = 100 # 3 min
       |  restart-strategy.attempts = 1 # retry once


### PR DESCRIPTION
1. Compressed checkpointing - configurable enable/disable
2. Pause between two checkpoints to get the guaranteed progress.