### PR TITLE
Separate redis host for relation cache and content cache

### DIFF
--- a/jobs-core/src/main/scala/org/sunbird/job/cache/RedisConnect.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/cache/RedisConnect.scala
@@ -5,15 +5,14 @@ import org.slf4j.LoggerFactory
 import org.sunbird.job.BaseJobConfig
 import redis.clients.jedis.Jedis
 
-class RedisConnect(jobConfig: BaseJobConfig) extends java.io.Serializable {
+class RedisConnect(jobConfig: BaseJobConfig, host: Option[String] = None, port: Option[Int] = None) extends java.io.Serializable {
 
   private val serialVersionUID = -396824011996012513L
 
   val config: Config = jobConfig.config
-  val redisHost: String = Option(config.getString("redis.host")).getOrElse("localhost")
-  val redisPort: Int = Option(config.getInt("redis.port")).getOrElse(6379)
+  val redisHost: String = host.getOrElse(Option(config.getString("redis.host")).getOrElse("localhost"))
+  val redisPort: Int = port.getOrElse(Option(config.getInt("redis.port")).getOrElse(6379))
   private val logger = LoggerFactory.getLogger(classOf[RedisConnect])
-
 
   private def getConnection(backoffTimeInMillis: Long): Jedis = {
     val defaultTimeOut = 30000

--- a/relation-cache-updater/src/main/resources/relation-cache-updater.conf
+++ b/relation-cache-updater/src/main/resources/relation-cache-updater.conf
@@ -16,8 +16,11 @@ lms-cassandra {
 }
 
 redis {
-  database {
-    relationCache.id = 10
-    collectionCache.id = 5
-  }
+  database.index = 10
+}
+
+dp-redis {
+  host = 11.2.4.22
+  port = 6379
+  database.index = 5
 }

--- a/relation-cache-updater/src/main/scala/org/sunbird/job/task/RelationCacheUpdaterConfig.scala
+++ b/relation-cache-updater/src/main/scala/org/sunbird/job/task/RelationCacheUpdaterConfig.scala
@@ -37,7 +37,9 @@ class RelationCacheUpdaterConfig(override val config: Config) extends BaseJobCon
   val hierarchyPrimaryKey: List[String] = List("identifier")
 
   // Redis Configurations
-  val relationCacheStore: Int = config.getInt("redis.database.relationCache.id")
-  val collectionCacheStore: Int = config.getInt("redis.database.collectionCache.id")
+  val relationCacheStore: Int = config.getInt("redis.database.index")
+  val dpRedisHost: String = config.getString("dp-redis.host")
+  val dpRedisPort: Int = config.getInt("dp-redis.port")
+  val collectionCacheStore: Int = config.getInt("dp-redis.database.index")
 
 }

--- a/relation-cache-updater/src/test/resources/test.conf
+++ b/relation-cache-updater/src/test/resources/test.conf
@@ -17,8 +17,11 @@ lms-cassandra {
 }
 
 redis {
-  database {
-    relationCache.id = 10
-    collectionCache.id = 5
-  }
+  database.index = 10
+}
+
+dp-redis {
+  host = localhost
+  port = 6340
+  database.index = 5
 }


### PR DESCRIPTION
Separate cache host used for relation cache and content cache (used by data-pipeline).