### PR TITLE
TG-948 added the auto build deploy JF

### DIFF
--- a/kubernets/pipelines/build/auto_build_deploy
+++ b/kubernets/pipelines/build/auto_build_deploy
@@ -1,0 +1,64 @@
+@Library('deploy-conf') _
+node('build-slave') {
+    try {
+        String ANSI_GREEN = "\u001B[32m"
+        String ANSI_NORMAL = "\u001B[0m"
+        String ANSI_BOLD = "\u001B[1m"
+        String ANSI_RED = "\u001B[31m"
+        String ANSI_YELLOW = "\u001B[33m"
+
+        ansiColor('xterm') {
+            withEnv(["JAVA_HOME=${JAVA11_HOME}"]) {
+                stage('Checkout') {
+                    tag_name = env.JOB_NAME.split("/")[-1]
+                    pre_checks()
+                    if (!env.hub_org) {
+                        println(ANSI_BOLD + ANSI_RED + "Uh Oh! Please set a Jenkins environment variable named hub_org with value as registery/sunbidrded" + ANSI_NORMAL)
+                        error 'Please resolve the errors and rerun..'
+                    } else
+                        println(ANSI_BOLD + ANSI_GREEN + "Found environment variable named hub_org with value as: " + hub_org + ANSI_NORMAL)
+                }
+                cleanWs()
+                def scmVars = checkout scm
+                checkout scm: [$class: 'GitSCM', branches: [[name: "refs/tags/$tag_name"]], userRemoteConfigs: [[url: scmVars.GIT_URL]]]
+                build_tag = tag_name + "_" + env.BUILD_NUMBER
+                commit_hash = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
+                artifact_version = tag_name + "_" + commit_hash
+                echo "build_tag: " + build_tag
+
+                //   stage Build
+                        env.NODE_ENV = "build"
+                        print "Environment will be : ${env.NODE_ENV}"
+                        sh '/opt/apache-maven-3.6.3/bin/mvn3.6 clean install -DskipTests'
+
+                //   stage Package
+                        dir('jobs-distribution') {
+                        sh "/opt/apache-maven-3.6.3/bin/mvn3.6 package -Pbuild-docker-image -Drelease-version=${build_tag}"
+                }
+
+
+                //   stage Retagging
+                         sh """
+                            docker tag knowledge-platform-jobs:${build_tag} ${hub_org}/knowledge-platform-jobs:${build_tag}
+                  echo {\\"image_name\\" : \\"knowledge-platform-jobs\\", \\"image_tag\\" : \\"${build_tag}\\", \\"node_name\\" : \\"${env.NODE_NAME}\\"} > metadata.json
+                            """
+
+               //   stage ArchiveArtifacts
+                        archiveArtifacts "metadata.json"
+                        currentBuild.description = "${build_tag}"
+
+
+            }
+            currentBuild.result = "SUCCESS"
+            slack_notify(currentBuild.result, tag_name)
+            email_notify()
+            auto_build_deploy()
+        }
+    }
+    catch (err) {
+        currentBuild.result = "FAILURE"
+        slack_notify(currentBuild.result, tag_name)
+        email_notify()
+        throw err
+    }
+}


### PR DESCRIPTION
This PR required to enable the auto deployment for flink jobs in staging env.
So here after all the flink jobs will get deployed in staging env whenever there is a new tag created.
And the dev team will provide the list of jobs that needs to be deployed in preprod and prod at end of the release.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran the dry run with fork repo
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules