### PR TITLE
SC-1914 fix: Flink Jobs Error Handling 

### DIFF
--- a/asset-enrichment/src/main/scala/org/sunbird/job/assetenricment/functions/ImageEnrichmentFunction.scala
+++ b/asset-enrichment/src/main/scala/org/sunbird/job/assetenricment/functions/ImageEnrichmentFunction.scala
@@ -9,6 +9,7 @@ import org.sunbird.job.assetenricment.models.Asset
 import org.sunbird.job.assetenricment.task.AssetEnrichmentConfig
 import org.sunbird.job.assetenricment.util.CloudStorageUtil
 import org.sunbird.job.domain.`object`.DefinitionCache
+import org.sunbird.job.exception.InvalidEventException
 import org.sunbird.job.util.Neo4JUtil
 import org.sunbird.job.{BaseProcessFunction, Metrics}
 
@@ -31,7 +32,7 @@ class ImageEnrichmentFunction(config: AssetEnrichmentConfig,
   override def close(): Unit = {
     super.close()
   }
-
+  @throws(classOf[InvalidEventException])
   override def processElement(event: Event, context: ProcessFunction[Event, String]#Context, metrics: Metrics): Unit = {
     logger.info(s"Received message for Image Enrichment for identifier : ${event.id}.")
     metrics.incCounter(config.imageEnrichmentEventCount)
@@ -45,7 +46,7 @@ class ImageEnrichmentFunction(config: AssetEnrichmentConfig,
       case ex: Exception =>
         logger.error(s"Error while processing message for Image Enrichment for identifier : ${asset.identifier}.", ex)
         metrics.incCounter(config.failedImageEnrichmentEventCount)
-        throw ex
+        throw new InvalidEventException(ex.getMessage, Map("partition" -> event.partition, "offset" -> event.offset), ex)
     }
   }
 

--- a/asset-enrichment/src/main/scala/org/sunbird/job/assetenricment/functions/VideoEnrichmentFunction.scala
+++ b/asset-enrichment/src/main/scala/org/sunbird/job/assetenricment/functions/VideoEnrichmentFunction.scala
@@ -8,6 +8,7 @@ import org.sunbird.job.assetenricment.helpers.{OptimizerHelper, VideoEnrichmentH
 import org.sunbird.job.assetenricment.models.Asset
 import org.sunbird.job.assetenricment.task.AssetEnrichmentConfig
 import org.sunbird.job.assetenricment.util.{CloudStorageUtil, YouTubeUtil}
+import org.sunbird.job.exception.InvalidEventException
 import org.sunbird.job.util.Neo4JUtil
 import org.sunbird.job.{BaseProcessFunction, Metrics}
 
@@ -30,7 +31,7 @@ class VideoEnrichmentFunction(config: AssetEnrichmentConfig,
   override def close(): Unit = {
     super.close()
   }
-
+  @throws(classOf[InvalidEventException])
   override def processElement(event: Event, context: ProcessFunction[Event, String]#Context, metrics: Metrics): Unit = {
     logger.info(s"Received message for Video Enrichment for identifier : ${event.id}.")
     metrics.incCounter(config.videoEnrichmentEventCount)
@@ -45,7 +46,7 @@ class VideoEnrichmentFunction(config: AssetEnrichmentConfig,
       case ex: Exception =>
         logger.error(s"Error while processing message for Video Enrichment for identifier : ${asset.identifier}.", ex)
         metrics.incCounter(config.failedVideoEnrichmentEventCount)
-        throw ex
+        throw new InvalidEventException(ex.getMessage, Map("partition" -> event.partition, "offset" -> event.offset), ex)
     }
   }
 

--- a/enrolment-reconciliation/src/main/scala/org/sunbird/job/recounciliation/domain/Event.scala
+++ b/enrolment-reconciliation/src/main/scala/org/sunbird/job/recounciliation/domain/Event.scala
@@ -1,0 +1,28 @@
+package org.sunbird.job.recounciliation.domain
+import org.apache.commons.lang3.StringUtils
+import org.sunbird.job.domain.reader.JobRequest
+
+import java.util
+
+class Event(eventMap: java.util.Map[String, Any], partition: Int, offset: Long) extends JobRequest(eventMap, partition, offset) {
+
+  val jobName = "EnrolmentReconciliation"
+
+  def eData: Map[String, AnyRef] = readOrDefault("edata", new util.HashMap[String, AnyRef]()).asInstanceOf[Map[String, AnyRef]]
+
+  def action: String = readOrDefault[String]("edata.action", "")
+
+  def courseId: String = readOrDefault[String]("edata.courseId", "")
+
+  def batchId: String = readOrDefault[String]("edata.batchId", "")
+
+  def userId: String = readOrDefault[String]("edata.userId", "")
+
+  def eType: String = readOrDefault[String]("edata.action", "")
+
+  def isValidEvent(supportedEventType: String): Boolean = {
+
+    StringUtils.equalsIgnoreCase(eType, supportedEventType)
+  }
+
+}

--- a/enrolment-reconciliation/src/main/scala/org/sunbird/job/recounciliation/functions/EnrolmentReconciliationFn.scala
+++ b/enrolment-reconciliation/src/main/scala/org/sunbird/job/recounciliation/functions/EnrolmentReconciliationFn.scala
@@ -25,7 +25,7 @@ import scala.collection.JavaConverters._
 
 class EnrolmentReconciliationFn(config: EnrolmentReconciliationConfig,  httpUtil: HttpUtil, @transient var cassandraUtil: CassandraUtil = null)
                                (implicit val stringTypeInfo: TypeInformation[String])
-  extends BaseProcessFunction[java.util.Map[String, AnyRef], String](config) {
+  extends BaseProcessFunction[Event, String](config) {
 
   private[this] val logger = LoggerFactory.getLogger(classOf[EnrolmentReconciliationFn])
   val mapType: Type = new TypeToken[java.util.Map[String, AnyRef]]() {}.getType
@@ -62,17 +62,12 @@ class EnrolmentReconciliationFn(config: EnrolmentReconciliationConfig,  httpUtil
   }
 
 
-  override def processElement(event: java.util.Map[String, AnyRef], context: ProcessFunction[java.util.Map[String, AnyRef], String]#Context, metrics: Metrics): Unit = {
+  override def processElement(event: Event, context: ProcessFunction[Event, String]#Context, metrics: Metrics): Unit = {
     metrics.incCounter(config.totalEventCount)
-    val eData = event.asScala.getOrElse("edata", Map()).asInstanceOf[java.util.Map[String, AnyRef]].asScala
-    if (isValidEvent(eData.getOrElse("action", "").asInstanceOf[String])) {
-      val courseId = eData.getOrElse("courseId", "").asInstanceOf[String]
-      val batchId = eData.getOrElse("batchId", "").asInstanceOf[String]
-      val userId = eData.getOrElse("userId", "").asInstanceOf[String]
+    if (event.isValidEvent(config.supportedEventType)) {
       // Fetch the content status from the table in batch format
       val dbUserConsumption: List[UserContentConsumption] = getContentStatusFromDB(
-        Map("courseId" -> courseId, "userId" -> userId, "batchId" -> batchId),
-        metrics)
+        Map("courseId" -> event.courseId, "userId" -> event.userId, "batchId" -> event.batchId), metrics)
 
       val courseAggregations = dbUserConsumption.flatMap{ userConsumption =>
         // Course Level Agg using the merged data of ContentConsumption per user, course and batch.
@@ -104,10 +99,6 @@ class EnrolmentReconciliationFn(config: EnrolmentReconciliationConfig,  httpUtil
       logger.info("Event skipped as it is invalid ", event)
     }
 
-  }
-
-  def isValidEvent(eType: String): Boolean = {
-    StringUtils.equalsIgnoreCase(eType, config.supportedEventType)
   }
 
   def getUserAggQuery(progress: UserActivityAgg):
@@ -224,7 +215,7 @@ class EnrolmentReconciliationFn(config: EnrolmentReconciliationConfig,  httpUtil
   /**
    * Course Level Agg using the merged data of ContentConsumption per user, course and batch.
    */
-  def courseActivityAgg(userConsumption: UserContentConsumption, context: ProcessFunction[java.util.Map[String, AnyRef], String]#Context)(implicit metrics: Metrics): Option[UserEnrolmentAgg] = {
+  def courseActivityAgg(userConsumption: UserContentConsumption, context: ProcessFunction[Event, String]#Context)(implicit metrics: Metrics): Option[UserEnrolmentAgg] = {
     val courseId = userConsumption.courseId
     val userId = userConsumption.userId
     val contextId = "cb:" + userConsumption.batchId

--- a/enrolment-reconciliation/src/main/scala/org/sunbird/job/recounciliation/task/EnrolmentReconciliationStreamTask.scala
+++ b/enrolment-reconciliation/src/main/scala/org/sunbird/job/recounciliation/task/EnrolmentReconciliationStreamTask.scala
@@ -6,7 +6,7 @@ import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.sunbird.job.connector.FlinkKafkaConnector
-import org.sunbird.job.recounciliation.domain.CollectionProgress
+import org.sunbird.job.recounciliation.domain.{CollectionProgress, Event}
 import org.sunbird.job.recounciliation.functions.{EnrolmentReconciliationFn, ProgressCompleteFunction, ProgressUpdateFunction}
 import org.sunbird.job.util.{FlinkUtil, HttpUtil}
 
@@ -20,7 +20,8 @@ class EnrolmentReconciliationStreamTask(config: EnrolmentReconciliationConfig, k
     implicit val mapTypeInfo: TypeInformation[util.Map[String, AnyRef]] = TypeExtractor.getForClass(classOf[util.Map[String, AnyRef]])
     implicit val stringTypeInfo: TypeInformation[String] = TypeExtractor.getForClass(classOf[String])
     implicit val enrolmentCompleteTypeInfo: TypeInformation[List[CollectionProgress]] = TypeExtractor.getForClass(classOf[List[CollectionProgress]])
-    val source = kafkaConnector.kafkaMapSource(config.kafkaInputTopic)
+    implicit val eventTypeInfo: TypeInformation[Event] = TypeExtractor.getForClass(classOf[Event])
+    val source = kafkaConnector.kafkaJobRequestSource[Event](config.kafkaInputTopic)
 
     val progressStream = env.addSource(source).name(config.enrolmentReconciliationConsumer)
       .uid(config.enrolmentReconciliationConsumer).setParallelism(config.kafkaConsumerParallelism)

--- a/enrolment-reconciliation/src/test/scala/org/sunbird/job/spec/EnrolmentReconciliationStreamTaskSpec.scala
+++ b/enrolment-reconciliation/src/test/scala/org/sunbird/job/spec/EnrolmentReconciliationStreamTaskSpec.scala
@@ -16,8 +16,9 @@ import org.mockito.Mockito._
 import org.sunbird.job.cache.RedisConnect
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.fixture.EventFixture
+import org.sunbird.job.recounciliation.domain.Event
 import org.sunbird.job.recounciliation.task.{EnrolmentReconciliationConfig, EnrolmentReconciliationStreamTask}
-import org.sunbird.job.util.{CassandraUtil, HttpUtil}
+import org.sunbird.job.util.{CassandraUtil, HttpUtil, JSONUtil}
 import org.sunbird.spec.{BaseMetricsReporter, BaseTestSpec}
 import redis.clients.jedis.Jedis
 import redis.embedded.RedisServer
@@ -80,7 +81,7 @@ class EnrolmentReconciliationStreamTaskSpec extends BaseTestSpec {
   }
 
   def initialize() {
-    when(mockKafkaUtil.kafkaMapSource(jobConfig.kafkaInputTopic)).thenReturn(new EnrolmentReconciliationMapSource)
+    when(mockKafkaUtil.kafkaJobRequestSource[Event](jobConfig.kafkaInputTopic)).thenReturn(new EnrolmentReconciliationEventSource)
     when(mockKafkaUtil.kafkaStringSink(jobConfig.kafkaAuditEventTopic)).thenReturn(new AuditEventSink)
     when(mockKafkaUtil.kafkaStringSink(jobConfig.kafkaFailedEventTopic)).thenReturn(new FailedEventSink)
     when(mockKafkaUtil.kafkaStringSink(jobConfig.kafkaCertIssueTopic)).thenReturn(new CertificateIssuedEventsSink)
@@ -109,16 +110,12 @@ class EnrolmentReconciliationStreamTaskSpec extends BaseTestSpec {
 
 }
 
-class EnrolmentReconciliationMapSource extends SourceFunction[java.util.Map[String, AnyRef]] {
-  override def run(ctx: SourceContext[util.Map[String, AnyRef]]): Unit = {
-    val gson = new Gson()
-    val eventMap1 = gson.fromJson(EventFixture.EVENT_1, new util.LinkedHashMap[String, AnyRef]().getClass).asInstanceOf[util.Map[String, AnyRef]].asScala
-    val eventMap2 = gson.fromJson(EventFixture.EVENT_2, new util.LinkedHashMap[String, AnyRef]().getClass).asInstanceOf[util.Map[String, AnyRef]].asScala
-    ctx.collect(eventMap1.asJava)
-    ctx.collect(eventMap2.asJava)
+class EnrolmentReconciliationEventSource extends SourceFunction[Event] {
+  override def run(ctx: SourceContext[Event]): Unit = {
+    ctx.collect(new Event(JSONUtil.deserialize[util.Map[String, Any]](EventFixture.EVENT_1), 0, 10))
+    ctx.collect(new Event(JSONUtil.deserialize[util.Map[String, Any]](EventFixture.EVENT_2), 0, 11))
   }
-
   override def cancel(): Unit = {}
-  
+
 }
 

--- a/jobs-core/src/main/scala/org/sunbird/job/exception/InvalidEventException.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/exception/InvalidEventException.scala
@@ -1,0 +1,14 @@
+package org.sunbird.job.exception
+
+import org.slf4j.LoggerFactory
+
+class InvalidEventException(message: String) extends Exception(message) {
+  private[this] val logger = LoggerFactory.getLogger(classOf[InvalidEventException])
+
+  def this(message: String, event: Map[String, Any], cause: Throwable) = {
+    this(message)
+    val partitionNum = event.getOrElse("partition", null)
+    val offset = event.getOrElse("offset", null)
+    logger.error(s"Error while processing message for Partition: ${partitionNum} and Offset: ${offset}. Error : $message", cause.getStackTrace)
+  }
+}

--- a/relation-cache-updater/src/main/scala/org/sunbird/job/relationcache/domain/Event.scala
+++ b/relation-cache-updater/src/main/scala/org/sunbird/job/relationcache/domain/Event.scala
@@ -1,0 +1,27 @@
+package org.sunbird.job.relationcache.domain
+
+import org.apache.commons.lang3.StringUtils
+import org.sunbird.job.domain.reader.JobRequest
+
+import java.util
+
+class Event(eventMap: java.util.Map[String, Any], partition: Int, offset: Long) extends JobRequest(eventMap, partition, offset) {
+
+  val jobName = "RelationCacheUpdater"
+
+  def identifier: String = readOrDefault[String]("edata.identifier", "")
+
+  def action: String = readOrDefault[String]("edata.action", "")
+
+  def mimeType: String = readOrDefault[String]("edata.mimeType", "")
+
+  def eData: Map[String, AnyRef] = readOrDefault("edata", new util.HashMap[String, AnyRef]()).asInstanceOf[Map[String, AnyRef]]
+
+
+  def isValidEvent(allowedActions:List[String]): Boolean = {
+
+    allowedActions.contains(action) && StringUtils.equalsIgnoreCase(mimeType, "application/vnd.ekstep.content-collection") &&
+      StringUtils.isNotBlank(identifier)
+  }
+
+}

--- a/relation-cache-updater/src/main/scala/org/sunbird/job/relationcache/functions/RelationCacheUpdater.scala
+++ b/relation-cache-updater/src/main/scala/org/sunbird/job/relationcache/functions/RelationCacheUpdater.scala
@@ -57,7 +57,6 @@ class RelationCacheUpdater(config: RelationCacheUpdaterConfig)
     override def processElement(event: Event, context: ProcessFunction[Event, String]#Context, metrics: Metrics): Unit = {
         if (event.isValidEvent(allowedActions)) {
             val rootId = event.identifier
-            println("Processing - identifier: " + rootId)
             logger.info("Processing - identifier: " + rootId)
             val hierarchy = getHierarchy(rootId)(metrics)
             if (MapUtils.isNotEmpty(hierarchy)) {

--- a/relation-cache-updater/src/main/scala/org/sunbird/job/relationcache/task/RelationCacheUpdaterStreamTask.scala
+++ b/relation-cache-updater/src/main/scala/org/sunbird/job/relationcache/task/RelationCacheUpdaterStreamTask.scala
@@ -2,13 +2,13 @@ package org.sunbird.job.relationcache.task
 
 import java.io.File
 import java.util
-
 import com.typesafe.config.ConfigFactory
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.sunbird.job.connector.FlinkKafkaConnector
+import org.sunbird.job.relationcache.domain.Event
 import org.sunbird.job.relationcache.functions.RelationCacheUpdater
 import org.sunbird.job.util.FlinkUtil
 
@@ -16,9 +16,10 @@ import org.sunbird.job.util.FlinkUtil
 class RelationCacheUpdaterStreamTask(config: RelationCacheUpdaterConfig, kafkaConnector: FlinkKafkaConnector) {
   def process(): Unit = {
     implicit val env: StreamExecutionEnvironment = FlinkUtil.getExecutionContext(config)
+    implicit val eventTypeInfo: TypeInformation[Event] = TypeExtractor.getForClass(classOf[Event])
     implicit val mapTypeInfo: TypeInformation[util.Map[String, AnyRef]] = TypeExtractor.getForClass(classOf[util.Map[String, AnyRef]])
     implicit val stringTypeInfo: TypeInformation[String] = TypeExtractor.getForClass(classOf[String])
-    val source = kafkaConnector.kafkaMapSource(config.kafkaInputTopic)
+    val source = kafkaConnector.kafkaJobRequestSource[Event](config.kafkaInputTopic)
 
     env.addSource(source).name(config.relationCacheConsumer)
       .uid(config.relationCacheConsumer).setParallelism(config.kafkaConsumerParallelism)

--- a/relation-cache-updater/src/test/scala/org/sunbird/job/spec/RelationCacheUpdaterTaskTestSpec.scala
+++ b/relation-cache-updater/src/test/scala/org/sunbird/job/spec/RelationCacheUpdaterTaskTestSpec.scala
@@ -1,7 +1,6 @@
 package org.sunbird.job.spec
 
 import java.util
-
 import com.google.gson.Gson
 import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.flink.api.common.typeinfo.TypeInformation
@@ -18,8 +17,9 @@ import org.mockito.Mockito._
 import org.sunbird.job.cache.RedisConnect
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.fixture.EventFixture
+import org.sunbird.job.relationcache.domain.Event
 import org.sunbird.job.relationcache.task.{RelationCacheUpdaterConfig, RelationCacheUpdaterStreamTask}
-import org.sunbird.job.util.CassandraUtil
+import org.sunbird.job.util.{CassandraUtil, JSONUtil}
 import org.sunbird.spec.{BaseMetricsReporter, BaseTestSpec}
 import redis.clients.jedis.Jedis
 import redis.embedded.RedisServer
@@ -82,7 +82,7 @@ class RelationCacheUpdaterTaskTestSpec extends BaseTestSpec {
 
 
   "RelationCacheUpdater " should "generate cache" in {
-    when(mockKafkaUtil.kafkaMapSource(jobConfig.kafkaInputTopic)).thenReturn(new RelationCacheUpdaterMapSource)
+    when(mockKafkaUtil.kafkaJobRequestSource[Event](jobConfig.kafkaInputTopic)).thenReturn(new RelationCacheUpdaterEventSource)
     new RelationCacheUpdaterStreamTask(jobConfig, mockKafkaUtil).process()
     BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.totalEventsCount}").getValue() should be(2)
     BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.successEventCount}").getValue() should be(2)
@@ -144,13 +144,10 @@ class RelationCacheUpdaterTaskTestSpec extends BaseTestSpec {
 
 }
 
-class RelationCacheUpdaterMapSource extends SourceFunction[java.util.Map[String, AnyRef]] {
-  override def run(ctx: SourceContext[util.Map[String, AnyRef]]): Unit = {
-    val gson = new Gson()
-    val eventMap1 = gson.fromJson(EventFixture.EVENT_1, new util.LinkedHashMap[String, AnyRef]().getClass).asInstanceOf[util.Map[String, AnyRef]].asScala
-    val eventMap2 = gson.fromJson(EventFixture.EVENT_2, new util.LinkedHashMap[String, AnyRef]().getClass).asInstanceOf[util.Map[String, AnyRef]].asScala
-    ctx.collect(eventMap1.asJava)
-    ctx.collect(eventMap2.asJava)
+class RelationCacheUpdaterEventSource extends SourceFunction[Event] {
+  override def run(ctx: SourceContext[Event]): Unit = {
+    ctx.collect(new Event(JSONUtil.deserialize[util.Map[String, Any]](EventFixture.EVENT_1), 0, 10))
+    ctx.collect(new Event(JSONUtil.deserialize[util.Map[String, Any]](EventFixture.EVENT_2), 0, 11))
   }
 
   override def cancel() = {}

--- a/search-indexer/src/main/scala/org/sunbird/job/searchindexer/functions/DIALCodeIndexerFunction.scala
+++ b/search-indexer/src/main/scala/org/sunbird/job/searchindexer/functions/DIALCodeIndexerFunction.scala
@@ -3,6 +3,7 @@ package org.sunbird.job.searchindexer.functions
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.functions.ProcessFunction
 import org.slf4j.LoggerFactory
+import org.sunbird.job.exception.InvalidEventException
 import org.sunbird.job.searchindexer.compositesearch.domain.Event
 import org.sunbird.job.searchindexer.compositesearch.helpers.{DIALCodeIndexerHelper, FailedEventHelper}
 import org.sunbird.job.searchindexer.task.SearchIndexerConfig
@@ -28,6 +29,7 @@ class DIALCodeIndexerFunction(config: SearchIndexerConfig,
     super.close()
   }
 
+  @throws(classOf[InvalidEventException])
   override def processElement(event: Event, context: ProcessFunction[Event, String]#Context, metrics: Metrics): Unit = {
     metrics.incCounter(config.dialcodeExternalEventCount)
     try {
@@ -39,7 +41,7 @@ class DIALCodeIndexerFunction(config: SearchIndexerConfig,
         metrics.incCounter(config.failedDialcodeExternalEventCount)
         val failedEvent = getFailedEvent(event, ex)
         context.output(config.failedEventOutTag, failedEvent)
-        throw ex
+        throw new InvalidEventException(ex.getMessage, Map("partition" -> event.partition, "offset" -> event.offset), ex)
     }
   }
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SC-1914" title="SC-1914" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10315&avatarType=issuetype" />SC-1914</a>  Migrate the video streaming job into a flink job
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
	1. Changing from map source to event source
        2. Created a custom invalid event exception to trace the error easily.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules