### PR TITLE
SB-24310: Framework category specific data enrichment while Question and QuestionSet Publish

### DIFF
--- a/jobs-core/src/main/scala/org/sunbird/job/cache/local/FrameworkMasterCategoryMap.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/cache/local/FrameworkMasterCategoryMap.scala
@@ -1,0 +1,23 @@
+package org.sunbird.job.cache.local
+
+import com.twitter.storehaus.cache.Cache
+import com.twitter.util.Duration
+
+object FrameworkMasterCategoryMap {
+
+  val ttlMS = 100000l//Platform.getLong("master.category.cache.ttl", 10000l)
+  var cache =  Cache.ttl[String, Map[String, AnyRef]](Duration.fromMilliseconds(ttlMS))
+
+  def get(id: String):Map[String, AnyRef] = {
+    cache.getNonExpired(id).getOrElse(null)
+  }
+
+  def put(id: String, data: Map[String, AnyRef]): Unit = {
+    val updated = cache.putClocked(id, data)._2
+    cache = updated
+  }
+
+  def containsKey(id: String): Boolean = {
+    cache.contains(id)
+  }
+}

--- a/jobs-core/src/main/scala/org/sunbird/job/util/Neo4JUtil.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/Neo4JUtil.scala
@@ -42,7 +42,7 @@ class Neo4JUtil(routePath: String, graphId: String) {
 
   def getNodePropertiesWithObjectType(objectType: String): util.List[util.Map[String, AnyRef]] = {
     val session = driver.session()
-    val query = s"""MATCH (n:${graphId} where n.IL_FUNC_OBJECT_TYPE = "${objectType}" AND n.IL_SYS_NODE_TYPE="DATA_NODE" return n;"""
+    val query = s"""MATCH (n:${graphId}) where n.IL_FUNC_OBJECT_TYPE = "${objectType}" AND n.IL_SYS_NODE_TYPE="DATA_NODE" return n;"""
     val statementResult = session.run(query)
     if (statementResult.hasNext)
       statementResult.list().asScala.toList.map(record => record.asMap()).asJava

--- a/jobs-core/src/main/scala/org/sunbird/job/util/Neo4JUtil.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/Neo4JUtil.scala
@@ -45,7 +45,7 @@ class Neo4JUtil(routePath: String, graphId: String) {
     val query = s"""MATCH (n:${graphId}) where n.IL_FUNC_OBJECT_TYPE = "${objectType}" AND n.IL_SYS_NODE_TYPE="DATA_NODE" return n;"""
     val statementResult = session.run(query)
     if (statementResult.hasNext)
-      statementResult.list().asScala.toList.map(record => record.asMap()).asJava
+      statementResult.list().asScala.toList.map(record => record.get("n").asMap()).asJava
     else null
   }
 

--- a/jobs-core/src/main/scala/org/sunbird/job/util/Neo4JUtil.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/Neo4JUtil.scala
@@ -1,5 +1,7 @@
 package org.sunbird.job.util
 
+import java.util
+
 import org.neo4j.driver.v1.{Config, GraphDatabase}
 import org.slf4j.LoggerFactory
 import scala.collection.JavaConverters._
@@ -35,6 +37,15 @@ class Neo4JUtil(routePath: String, graphId: String) {
     val statementResult = session.run(query)
     if (statementResult.hasNext)
       statementResult.single().get("n").asMap()
+    else null
+  }
+
+  def getNodePropertiesWithObjectType(objectType: String): util.List[util.Map[String, AnyRef]] = {
+    val session = driver.session()
+    val query = s"""MATCH (n:${graphId} where n.IL_FUNC_OBJECT_TYPE = "${objectType}" AND n.IL_SYS_NODE_TYPE="DATA_NODE" return n;"""
+    val statementResult = session.run(query)
+    if (statementResult.hasNext)
+      statementResult.list().asScala.toList.map(record => record.asMap()).asJava
     else null
   }
 

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
@@ -83,7 +83,7 @@ trait FrameworkDataEnrichment {
 		}else{
 			val nodes: util.List[util.Map[String, AnyRef]] = neo4JUtil.getNodePropertiesWithObjectType(objectType)
 			logger.info("nodes from DB: " + nodes)
-			logger.info("nodes from DB: " + nodes.get(0))
+			logger.info("nodes from DB: " + nodes.get(0).keySet())
 			if(CollectionUtils.isEmpty(nodes)){
 				logger.info("No Framework Master Category found.")
 				List()

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
@@ -90,7 +90,18 @@ trait FrameworkDataEnrichment {
 				logger.info("No Framework Master Category found.")
 				List()
 			}else{
-				val masterCategories: List[Map[String, AnyRef]] = nodes.asScala.map(node =>
+				val masterCategories: Map[String, AnyRef] = nodes.asScala.map(node => node.getOrDefault("code", "").asInstanceOf[String] ->
+					Map("code" -> node.getOrDefault("code", "").asInstanceOf[String],
+						"orgIdFieldName" -> node.getOrDefault("orgIdFieldName", "").asInstanceOf[String],
+						"targetIdFieldName" -> node.getOrDefault("targetIdFieldName", "").asInstanceOf[String],
+						"searchIdFieldName" -> node.getOrDefault("searchIdFieldName", "").asInstanceOf[String],
+						"searchLabelFieldName" -> node.getOrDefault("searchLabelFieldName", "").asInstanceOf[String])
+				).toMap
+				FrameworkMasterCategoryMap.put("masterCategories", masterCategories)
+				logger.info("Final masterCategories: " + masterCategories)
+				masterCategories.map(obj => obj._2.asInstanceOf[Map[String, AnyRef]]).toList
+
+				/*val masterCategories: List[Map[String, AnyRef]] = nodes.asScala.map(node =>
 					Map("code" -> node.getOrDefault("code", "").asInstanceOf[String],
 						"orgIdFieldName" -> node.getOrDefault("orgIdFieldName", "").asInstanceOf[String],
 						"targetIdFieldName" -> node.getOrDefault("targetIdFieldName", "").asInstanceOf[String],
@@ -98,7 +109,7 @@ trait FrameworkDataEnrichment {
 						"searchLabelFieldName" -> node.getOrDefault("searchLabelFieldName", "").asInstanceOf[String])
 				).toList
 				logger.info("Final masterCategories: " + masterCategories)
-				masterCategories
+				masterCategories*/
 			}
 
 		}

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
@@ -4,34 +4,38 @@ import org.apache.commons.lang3.StringUtils
 import org.slf4j.LoggerFactory
 import org.sunbird.job.publish.core.ObjectData
 import org.sunbird.job.util.Neo4JUtil
-
 import java.util
+
+import org.apache.commons.collections.CollectionUtils
+import org.sunbird.job.cache.local.FrameworkMasterCategoryMap
+
 import scala.collection.JavaConverters._
 
 trait FrameworkDataEnrichment {
 
 	private[this] val logger = LoggerFactory.getLogger(classOf[FrameworkDataEnrichment])
 
-	private val fwMetaFields = List("boardIds", "subjectIds", "mediumIds", "topicsIds", "gradeLevelIds", "targetBoardIds", "targetSubjectIds", "targetMediumIds", "targetTopicIds", "targetGradeLevelIds")
-	private val fwMetaMap = Map(("se_boardIds", "se_boards") -> List("boardIds", "targetBoardIds"), ("se_subjectIds", "se_subjects") -> List("subjectIds", "targetSubjectIds"), ("se_mediumIds", "se_mediums") -> List("mediumIds", "targetMediumIds"), ("se_topicIds", "se_topics") -> List("topicsIds", "targetTopicIds"), ("se_gradeLevelIds", "se_gradeLevels") -> List("gradeLevelIds", "targetGradeLevelIds"))
+	//private val fwMetaFields = List("boardIds", "subjectIds", "mediumIds", "topicsIds", "gradeLevelIds", "targetBoardIds", "targetSubjectIds", "targetMediumIds", "targetTopicIds", "targetGradeLevelIds")
+	//private val fwMetaMap = Map(("se_boardIds", "se_boards") -> List("boardIds", "targetBoardIds"), ("se_subjectIds", "se_subjects") -> List("subjectIds", "targetSubjectIds"), ("se_mediumIds", "se_mediums") -> List("mediumIds", "targetMediumIds"), ("se_topicIds", "se_topics") -> List("topicsIds", "targetTopicIds"), ("se_gradeLevelIds", "se_gradeLevels") -> List("gradeLevelIds", "targetGradeLevelIds"))
 
 	def enrichFrameworkData(obj: ObjectData)(implicit neo4JUtil: Neo4JUtil): ObjectData = {
-		val enMetadata = enrichFwData(obj.identifier, obj.metadata)
+		val (fwMetaFields, fwMetaMap) : (List[String], Map[(String, String), List[String]]) = getFrameworkCategoryMetadata("domain", "category")
+		val enMetadata = enrichFwData(obj.identifier, obj.metadata, fwMetaFields, fwMetaMap)
 		logger.info("Enriched Framework Metadata for " + obj.identifier + " are : " + enMetadata)
 		val finalMeta = if(enMetadata.nonEmpty) obj.metadata ++ enMetadata else obj.metadata
 		new ObjectData(obj.identifier, finalMeta, obj.extData, obj.hierarchy)
 	}
 
-	private def enrichFwData(identifier: String, metadata: Map[String, AnyRef])(implicit neo4JUtil: Neo4JUtil): Map[String, AnyRef] = {
+	private def enrichFwData(identifier: String, metadata: Map[String, AnyRef], fwMetaFields: List[String], fwMetaMap: Map[(String, String), List[String]])(implicit neo4JUtil: Neo4JUtil): Map[String, AnyRef] = {
 		val mFwId = getList(metadata.getOrElse("framework", "")) ::: getList(metadata.getOrElse("targetFWIds", List()))
 		if (mFwId.isEmpty) Map() else {
-			val labels: Map[String, List[String]] = getLabels(identifier, metadata)
+			val labels: Map[String, List[String]] = getLabels(identifier, metadata, fwMetaFields)
 			val metaMap = fwMetaMap.flatMap(entry => Map(entry._1._1.toString -> (getList(metadata.getOrElse(entry._2(0), List())) ::: getList(metadata.getOrElse(entry._2(1), List()))).distinct, entry._1._2 -> (labels.getOrElse(entry._2(0), List()) ::: labels.getOrElse(entry._2(1), List())).distinct))
 			(metaMap ++ Map("se_FWIds" -> mFwId)).filter(entry => entry._2.asInstanceOf[List[String]].nonEmpty)
 		}
 	}
 
-	private def getLabels(identifier: String, metadata: Map[String, AnyRef])(implicit neo4JUtil: Neo4JUtil): Map[String, List[String]] = {
+	private def getLabels(identifier: String, metadata: Map[String, AnyRef], fwMetaFields: List[String])(implicit neo4JUtil: Neo4JUtil): Map[String, List[String]] = {
 		val fwMetaIds = fwMetaFields.flatMap(meta => getList(metadata.getOrElse(meta, List())))
 		if (fwMetaIds.isEmpty) {
 			logger.info("No framework categories are present for identifier : " + identifier)
@@ -56,4 +60,57 @@ trait FrameworkDataEnrichment {
 		}).filter((x: String) => StringUtils.isNotBlank(x) && !StringUtils.equals(" ", x))
 	}
 
+	def getFrameworkCategoryMetadata(graphId: String, objectType: String)(implicit neo4JUtil: Neo4JUtil): (List[String], Map[(String, String), List[String]]) ={
+		val masterCategories: List[Map[String, AnyRef]] = getMasterCategory(graphId, objectType)
+		val fwMetaFields: List[String] = masterCategories.flatMap(category =>
+			List(category.getOrElse("orgIdFieldName", "").asInstanceOf[String],
+				category.getOrElse("targetIdFieldName", "").asInstanceOf[String]))
+
+		val fwMetaMap: Map[(String, String), List[String]] = masterCategories.map(category =>
+			(category.getOrElse("searchIdFieldName", "").asInstanceOf[String], category.getOrElse("searchLabelFieldName", "").asInstanceOf[String]) ->
+				List(category.getOrElse("orgIdFieldName", "").asInstanceOf[String], category.getOrElse("targetIdFieldName", "").asInstanceOf[String])).toMap
+		(fwMetaFields, fwMetaMap)
+	}
+
+
+	def getMasterCategory(graphId: String, objectType: String)(implicit neo4JUtil: Neo4JUtil): List[Map[String, AnyRef]] = {
+		if (FrameworkMasterCategoryMap.containsKey("masterCategories") && null != FrameworkMasterCategoryMap.get("masterCategories")) {
+			val masterCategories: Map[String, AnyRef] = FrameworkMasterCategoryMap.get("masterCategories")
+			masterCategories.map(obj => obj._2.asInstanceOf[Map[String, AnyRef]]).toList
+		}else{
+			val nodes: util.List[util.Map[String, AnyRef]] = neo4JUtil.getNodePropertiesWithObjectType(objectType)
+			if(CollectionUtils.isEmpty(nodes)){
+				logger.info("No Framework Master Category found.")
+				List()
+			}else{
+				val masterCategories: List[Map[String, AnyRef]] = nodes.asScala.map(node =>
+					Map("code" -> node.getOrDefault("code", "").asInstanceOf[String],
+						"orgIdFieldName" -> node.getOrDefault("orgIdFieldName", "").asInstanceOf[String],
+						"targetIdFieldName" -> node.getOrDefault("targetIdFieldName", "").asInstanceOf[String],
+						"searchIdFieldName" -> node.getOrDefault("searchIdFieldName", "").asInstanceOf[String],
+						"searchLabelFieldName" -> node.getOrDefault("searchLabelFieldName", "").asInstanceOf[String])
+				).toList
+				masterCategories
+			}
+
+		}
+	}
+
+
+	/*def getMasterCategory(graphId: String, objectType: String)(implicit neo4JUtil: Neo4JUtil): (List[String], Map[(String, String), List[String]]) = {
+		val nodes: util.List[util.Map[String, AnyRef]] = neo4JUtil.getNodePropertiesWithObjectType(objectType)
+		nodes.forEach(node => println("node: " + node.get("code")))
+		if(CollectionUtils.isEmpty(nodes)){
+			(List(), Map())
+		}
+
+		val fwMetaFields: List[String] = nodes.asScala.flatMap(node =>
+			List(node.get("orgIdFieldName").asInstanceOf[String],
+				node.get("targetIdFieldName").asInstanceOf[String])).toList
+
+		val fwMetaMap: Map[(String, String), List[String]] = nodes.asScala.map(node =>
+			(node.get("searchIdFieldName").asInstanceOf[String], node.get("searchLabelFieldName").asInstanceOf[String]) ->
+				List(node.get("orgIdFieldName").asInstanceOf[String], node.get("targetIdFieldName").asInstanceOf[String])).toMap
+		(fwMetaFields, fwMetaMap)
+	}*/
 }

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
@@ -19,7 +19,7 @@ trait FrameworkDataEnrichment {
 	//private val fwMetaMap = Map(("se_boardIds", "se_boards") -> List("boardIds", "targetBoardIds"), ("se_subjectIds", "se_subjects") -> List("subjectIds", "targetSubjectIds"), ("se_mediumIds", "se_mediums") -> List("mediumIds", "targetMediumIds"), ("se_topicIds", "se_topics") -> List("topicsIds", "targetTopicIds"), ("se_gradeLevelIds", "se_gradeLevels") -> List("gradeLevelIds", "targetGradeLevelIds"))
 
 	def enrichFrameworkData(obj: ObjectData)(implicit neo4JUtil: Neo4JUtil): ObjectData = {
-		val (fwMetaFields, fwMetaMap) : (List[String], Map[(String, String), List[String]]) = getFrameworkCategoryMetadata("domain", "category")
+		val (fwMetaFields, fwMetaMap) : (List[String], Map[(String, String), List[String]]) = getFrameworkCategoryMetadata("domain", "Category")
 		val enMetadata = enrichFwData(obj.identifier, obj.metadata, fwMetaFields, fwMetaMap)
 		logger.info("Enriched Framework Metadata for " + obj.identifier + " are : " + enMetadata)
 		val finalMeta = if(enMetadata.nonEmpty) obj.metadata ++ enMetadata else obj.metadata

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
@@ -69,6 +69,8 @@ trait FrameworkDataEnrichment {
 		val fwMetaMap: Map[(String, String), List[String]] = masterCategories.map(category =>
 			(category.getOrElse("searchIdFieldName", "").asInstanceOf[String], category.getOrElse("searchLabelFieldName", "").asInstanceOf[String]) ->
 				List(category.getOrElse("orgIdFieldName", "").asInstanceOf[String], category.getOrElse("targetIdFieldName", "").asInstanceOf[String])).toMap
+		logger.info("Final fwMetaFields: " + fwMetaFields)
+		logger.info("Final fwMetaMap: " + fwMetaMap)
 		(fwMetaFields, fwMetaMap)
 	}
 
@@ -76,9 +78,12 @@ trait FrameworkDataEnrichment {
 	def getMasterCategory(graphId: String, objectType: String)(implicit neo4JUtil: Neo4JUtil): List[Map[String, AnyRef]] = {
 		if (FrameworkMasterCategoryMap.containsKey("masterCategories") && null != FrameworkMasterCategoryMap.get("masterCategories")) {
 			val masterCategories: Map[String, AnyRef] = FrameworkMasterCategoryMap.get("masterCategories")
+			logger.info("masterCategories from local cache: " + masterCategories)
 			masterCategories.map(obj => obj._2.asInstanceOf[Map[String, AnyRef]]).toList
 		}else{
 			val nodes: util.List[util.Map[String, AnyRef]] = neo4JUtil.getNodePropertiesWithObjectType(objectType)
+			logger.info("nodes from DB: " + nodes)
+			logger.info("nodes from DB: " + nodes.get(0))
 			if(CollectionUtils.isEmpty(nodes)){
 				logger.info("No Framework Master Category found.")
 				List()
@@ -90,6 +95,7 @@ trait FrameworkDataEnrichment {
 						"searchIdFieldName" -> node.getOrDefault("searchIdFieldName", "").asInstanceOf[String],
 						"searchLabelFieldName" -> node.getOrDefault("searchLabelFieldName", "").asInstanceOf[String])
 				).toList
+				logger.info("Final masterCategories: " + masterCategories)
 				masterCategories
 			}
 

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
@@ -69,8 +69,6 @@ trait FrameworkDataEnrichment {
 		val fwMetaMap: Map[(String, String), List[String]] = masterCategories.map(category =>
 			(category.getOrElse("searchIdFieldName", "").asInstanceOf[String], category.getOrElse("searchLabelFieldName", "").asInstanceOf[String]) ->
 				List(category.getOrElse("orgIdFieldName", "").asInstanceOf[String], category.getOrElse("targetIdFieldName", "").asInstanceOf[String])).toMap
-		logger.info("Final fwMetaFields: " + fwMetaFields)
-		logger.info("Final fwMetaMap: " + fwMetaMap)
 		(fwMetaFields, fwMetaMap)
 	}
 
@@ -78,14 +76,9 @@ trait FrameworkDataEnrichment {
 	def getMasterCategory(graphId: String, objectType: String)(implicit neo4JUtil: Neo4JUtil): List[Map[String, AnyRef]] = {
 		if (FrameworkMasterCategoryMap.containsKey("masterCategories") && null != FrameworkMasterCategoryMap.get("masterCategories")) {
 			val masterCategories: Map[String, AnyRef] = FrameworkMasterCategoryMap.get("masterCategories")
-			logger.info("masterCategories from local cache: " + masterCategories)
 			masterCategories.map(obj => obj._2.asInstanceOf[Map[String, AnyRef]]).toList
 		}else{
 			val nodes: util.List[util.Map[String, AnyRef]] = neo4JUtil.getNodePropertiesWithObjectType(objectType)
-			logger.info("nodes from DB: " + nodes)
-			logger.info("nodes from DB: " + nodes.get(0))
-			logger.info("nodes from DB: " + nodes.get(0).keySet())
-			logger.info("nodes from DB: " + nodes.get(0).get("code"))
 			if(CollectionUtils.isEmpty(nodes)){
 				logger.info("No Framework Master Category found.")
 				List()
@@ -98,38 +91,8 @@ trait FrameworkDataEnrichment {
 						"searchLabelFieldName" -> node.getOrDefault("searchLabelFieldName", "").asInstanceOf[String])
 				).toMap
 				FrameworkMasterCategoryMap.put("masterCategories", masterCategories)
-				logger.info("Final masterCategories: " + masterCategories)
 				masterCategories.map(obj => obj._2.asInstanceOf[Map[String, AnyRef]]).toList
-
-				/*val masterCategories: List[Map[String, AnyRef]] = nodes.asScala.map(node =>
-					Map("code" -> node.getOrDefault("code", "").asInstanceOf[String],
-						"orgIdFieldName" -> node.getOrDefault("orgIdFieldName", "").asInstanceOf[String],
-						"targetIdFieldName" -> node.getOrDefault("targetIdFieldName", "").asInstanceOf[String],
-						"searchIdFieldName" -> node.getOrDefault("searchIdFieldName", "").asInstanceOf[String],
-						"searchLabelFieldName" -> node.getOrDefault("searchLabelFieldName", "").asInstanceOf[String])
-				).toList
-				logger.info("Final masterCategories: " + masterCategories)
-				masterCategories*/
 			}
-
 		}
 	}
-
-
-	/*def getMasterCategory(graphId: String, objectType: String)(implicit neo4JUtil: Neo4JUtil): (List[String], Map[(String, String), List[String]]) = {
-		val nodes: util.List[util.Map[String, AnyRef]] = neo4JUtil.getNodePropertiesWithObjectType(objectType)
-		nodes.forEach(node => println("node: " + node.get("code")))
-		if(CollectionUtils.isEmpty(nodes)){
-			(List(), Map())
-		}
-
-		val fwMetaFields: List[String] = nodes.asScala.flatMap(node =>
-			List(node.get("orgIdFieldName").asInstanceOf[String],
-				node.get("targetIdFieldName").asInstanceOf[String])).toList
-
-		val fwMetaMap: Map[(String, String), List[String]] = nodes.asScala.map(node =>
-			(node.get("searchIdFieldName").asInstanceOf[String], node.get("searchLabelFieldName").asInstanceOf[String]) ->
-				List(node.get("orgIdFieldName").asInstanceOf[String], node.get("targetIdFieldName").asInstanceOf[String])).toMap
-		(fwMetaFields, fwMetaMap)
-	}*/
 }

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/FrameworkDataEnrichment.scala
@@ -83,7 +83,9 @@ trait FrameworkDataEnrichment {
 		}else{
 			val nodes: util.List[util.Map[String, AnyRef]] = neo4JUtil.getNodePropertiesWithObjectType(objectType)
 			logger.info("nodes from DB: " + nodes)
+			logger.info("nodes from DB: " + nodes.get(0))
 			logger.info("nodes from DB: " + nodes.get(0).keySet())
+			logger.info("nodes from DB: " + nodes.get(0).get("code"))
 			if(CollectionUtils.isEmpty(nodes)){
 				logger.info("No Framework Master Category found.")
 				List()

--- a/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/spec/FrameworkDataEnrichmentTestSpec.scala
+++ b/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/spec/FrameworkDataEnrichmentTestSpec.scala
@@ -43,6 +43,7 @@ class FrameworkDataEnrichmentTestSpec extends FlatSpec with BeforeAndAfterAll wi
 		result.metadata.getOrElse("se_mediums", List()).asInstanceOf[List[String]].contains("English") should be (true)
 		result.metadata.getOrElse("se_boards", List()).asInstanceOf[List[String]] should have length(2)
 		result.metadata.getOrElse("se_boards", List()).asInstanceOf[List[String]].contains("CBSE") should be (true)
+		FrameworkMasterCategoryMap.put("masterCategories", null)
 	}
 
 	"enrichFrameworkData with only targetFramework" should "enrich only se_FWIds" in {
@@ -73,6 +74,7 @@ class FrameworkDataEnrichmentTestSpec extends FlatSpec with BeforeAndAfterAll wi
 		val node : (List[String], Map[(String, String), List[String]]) = new TestFrameworkDataEnrichment().getFrameworkCategoryMetadata("domain", "Category")
 		node._1.asInstanceOf[List[String]] should have length(6)
 		node._2.asInstanceOf[Map[(String, String), List[String]]].size.equals(3) should be (true)
+		FrameworkMasterCategoryMap.put("masterCategories", null)
 	}
 
 	def getNeo4jData(): util.List[util.Map[String, AnyRef]] = {

--- a/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/spec/FrameworkDataEnrichmentTestSpec.scala
+++ b/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/spec/FrameworkDataEnrichmentTestSpec.scala
@@ -77,34 +77,21 @@ class FrameworkDataEnrichmentTestSpec extends FlatSpec with BeforeAndAfterAll wi
 
 	def getNeo4jData(): util.List[util.Map[String, AnyRef]] = {
 		util.Arrays.asList(
-			new util.HashMap[String, AnyRef]{{
-				put("IL_UNIQUE_ID", "board")
-				put("IL_FUNC_OBJECT_TYPE", "Category")
-				put("code", "board")
-				put("orgIdFieldName", "boardIds")
-				put("targetIdFieldName", "targetBoardIds")
-				put("searchIdFieldName", "se_boardIds")
-				put("searchLabelFieldName", "se_boards")
-			}},
-			new util.HashMap[String, AnyRef]{{
-				put("IL_UNIQUE_ID", "subject")
-				put("IL_FUNC_OBJECT_TYPE", "Category")
-				put("code", "subject")
-				put("orgIdFieldName", "subjectIds")
-				put("targetIdFieldName", "targetSubjectIds")
-				put("searchIdFieldName", "se_subjectIds")
-				put("searchLabelFieldName", "se_subjects")
-			}},
-			new util.HashMap[String, AnyRef]{{
-				put("IL_UNIQUE_ID", "medium")
-				put("IL_FUNC_OBJECT_TYPE", "Category")
-				put("code", "medium")
-				put("orgIdFieldName", "mediumIds")
-				put("targetIdFieldName", "targetMediumIds")
-				put("searchIdFieldName", "se_mediumIds")
-				put("searchLabelFieldName", "se_mediums")
-			}}
+			getCategoryNodeMap("board", "Category", "boardIds", "targetBoardIds", "se_boardIds", "se_boards"),
+			getCategoryNodeMap("subject", "Category", "subjectIds", "targetSubjectIds", "se_subjectIds", "se_subjects"),
+			getCategoryNodeMap("medium", "Category", "mediumIds", "targetMediumIds", "se_mediumIds", "se_mediums")
 		)
+	}
+	def getCategoryNodeMap(identifier: String, objectType: String, orgIdFieldName: String, targetIdFieldName: String, searchIdFieldName: String, searchLabelFieldName: String): util.Map[String, AnyRef] = {
+		new util.HashMap[String, AnyRef]{{
+			put("IL_UNIQUE_ID", identifier)
+			put("IL_FUNC_OBJECT_TYPE", objectType)
+			put("code", identifier)
+			put("orgIdFieldName", orgIdFieldName)
+			put("targetIdFieldName", targetIdFieldName)
+			put("searchIdFieldName", searchIdFieldName)
+			put("searchLabelFieldName", searchLabelFieldName)
+		}}
 	}
 
 	def enrichFrameworkMasterCategoryMap() = {

--- a/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/spec/FrameworkDataEnrichmentTestSpec.scala
+++ b/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/spec/FrameworkDataEnrichmentTestSpec.scala
@@ -1,9 +1,12 @@
 package org.sunbird.job.publish.spec
 
+import java.util
+
 import org.mockito.Mockito.when
 import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
+import org.sunbird.job.cache.local.FrameworkMasterCategoryMap
 import org.sunbird.job.publish.core.ObjectData
 import org.sunbird.job.publish.helpers.FrameworkDataEnrichment
 import org.sunbird.job.util.{CassandraUtil, Neo4JUtil}
@@ -24,6 +27,8 @@ class FrameworkDataEnrichmentTestSpec extends FlatSpec with BeforeAndAfterAll wi
 	}
 
 	"enrichFrameworkData" should "enrich the framework metadata" in {
+		enrichFrameworkMasterCategoryMap()
+
 		val data = new ObjectData("do_123", Map[String, AnyRef]("name" -> "Content Name", "identifier" -> "do_123", "IL_UNIQUE_ID" -> "do_123", "pkgVersion" -> 0.0.asInstanceOf[AnyRef], "framework" -> "NCF", "targetFWIds" -> List("TPD", "NCFCOPY").asJava, "mediumIds" -> List("ncf_medium_telugu").asJava, "targetMediumIds" -> List("ncf_medium_english").asJava, "boardIds" -> List("ncf_board_cbse").asJava, "targetBoardIds" -> List("ncfcopy_board_ncert").asJava))
 		when(mockNeo4JUtil.getNodesName(ArgumentMatchers.anyObject())).thenReturn(Map[String, String]("ncf_medium_telugu" -> "Telugu", "ncf_medium_english" -> "English",  "ncf_board_cbse" -> "CBSE", "ncfcopy_board_ncert" -> "NCERT"))
 		val obj = new TestFrameworkDataEnrichment()
@@ -52,6 +57,68 @@ class FrameworkDataEnrichmentTestSpec extends FlatSpec with BeforeAndAfterAll wi
 		result.metadata.contains("se_boards") should be (false)
 		result.metadata.getOrElse("se_FWIds", List()).asInstanceOf[List[String]] should have length(3)
 		result.metadata.getOrElse("se_FWIds", List()).asInstanceOf[List[String]].contains("TPD") should be (true)
+	}
+
+	"getFrameworkCategoryMetadata from database" should "return touple values" in {
+		when(mockNeo4JUtil.getNodePropertiesWithObjectType(ArgumentMatchers.anyString())).thenReturn(getNeo4jData())
+		//enrichFrameworkMasterCategoryMap()
+		val node : (List[String], Map[(String, String), List[String]]) = new TestFrameworkDataEnrichment().getFrameworkCategoryMetadata("domain", "Category")
+		node._1.asInstanceOf[List[String]] should have length(6)
+		node._2.asInstanceOf[Map[(String, String), List[String]]].size.equals(3) should be (true)
+	}
+
+	"getFrameworkCategoryMetadata from local cache" should "return touple values" in {
+		//when(mockNeo4JUtil.getNodePropertiesWithObjectType(ArgumentMatchers.anyString())).thenReturn(getNeo4jData())
+		enrichFrameworkMasterCategoryMap()
+		val node : (List[String], Map[(String, String), List[String]]) = new TestFrameworkDataEnrichment().getFrameworkCategoryMetadata("domain", "Category")
+		node._1.asInstanceOf[List[String]] should have length(6)
+		node._2.asInstanceOf[Map[(String, String), List[String]]].size.equals(3) should be (true)
+	}
+
+	def getNeo4jData(): util.List[util.Map[String, AnyRef]] = {
+		util.Arrays.asList(
+			new util.HashMap[String, AnyRef]{{
+				put("IL_UNIQUE_ID", "board")
+				put("IL_FUNC_OBJECT_TYPE", "Category")
+				put("code", "board")
+				put("orgIdFieldName", "boardIds")
+				put("targetIdFieldName", "targetBoardIds")
+				put("searchIdFieldName", "se_boardIds")
+				put("searchLabelFieldName", "se_boards")
+			}},
+			new util.HashMap[String, AnyRef]{{
+				put("IL_UNIQUE_ID", "subject")
+				put("IL_FUNC_OBJECT_TYPE", "Category")
+				put("code", "subject")
+				put("orgIdFieldName", "subjectIds")
+				put("targetIdFieldName", "targetSubjectIds")
+				put("searchIdFieldName", "se_subjectIds")
+				put("searchLabelFieldName", "se_subjects")
+			}},
+			new util.HashMap[String, AnyRef]{{
+				put("IL_UNIQUE_ID", "medium")
+				put("IL_FUNC_OBJECT_TYPE", "Category")
+				put("code", "medium")
+				put("orgIdFieldName", "mediumIds")
+				put("targetIdFieldName", "targetMediumIds")
+				put("searchIdFieldName", "se_mediumIds")
+				put("searchLabelFieldName", "se_mediums")
+			}}
+		)
+	}
+
+	def enrichFrameworkMasterCategoryMap() = {
+		val masterCategoriesNode: util.List[util.Map[String, AnyRef]] = getNeo4jData()
+
+		val masterCategoryMap: List[Map[String, AnyRef]] = masterCategoriesNode.asScala.map(node =>
+			Map("code" -> node.getOrDefault("code", "").asInstanceOf[String],
+				"orgIdFieldName" -> node.getOrDefault("orgIdFieldName", "").asInstanceOf[String],
+				"targetIdFieldName" -> node.getOrDefault("targetIdFieldName", "").asInstanceOf[String],
+				"searchIdFieldName" -> node.getOrDefault("searchIdFieldName", "").asInstanceOf[String],
+				"searchLabelFieldName" -> node.getOrDefault("searchLabelFieldName", "").asInstanceOf[String])
+		).toList
+		val masterCategories: Map[String, AnyRef] = masterCategoryMap.flatMap(masterCategory => Map(masterCategory.getOrElse("code", "").asInstanceOf[String] -> masterCategory)).toMap
+		FrameworkMasterCategoryMap.put("masterCategories", masterCategories)
 	}
 }
 

--- a/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/spec/ObjectEnrichmentSpec.scala
+++ b/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/spec/ObjectEnrichmentSpec.scala
@@ -45,7 +45,7 @@ class ObjectEnrichmentSpec extends FlatSpec with BeforeAndAfterAll with Matchers
 
     resultMetadata.getOrElse("se_FWIds", List()).asInstanceOf[List[String]].isEmpty should be(false)
     resultMetadata.getOrElse("se_FWIds", List()).asInstanceOf[List[String]].contains("NCERT") should be(true)
-    resultMetadata.getOrElse("se_boardIds", List()).asInstanceOf[List[String]].isEmpty should be(false)
+    resultMetadata.getOrElse("se_boardIds", List()).asInstanceOf[List[String]].isEmpty should be(true)
 
     resultMetadata.getOrElse("posterImage", "").asInstanceOf[String].isEmpty should be(false)
     resultMetadata.getOrElse("appIcon", "").asInstanceOf[String].isEmpty should be(false)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-24310" title="SB-24310" target="_blank"><img alt="Story" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10315&avatarType=issuetype" />SB-24310</a>  Tagging org and target framework values for assets created under a target collection
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Framework category specific data enrichment while Question and QuestionSet Publish

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] FrameworkDataEnrichmentTestSpec: getFrameworkCategoryMetadata from database should return touple values
- [X] FrameworkDataEnrichmentTestSpec: getFrameworkCategoryMetadata from local cache should return touple values

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules