### PR TITLE
SC-1915 - Sequence the events to a specific pipeline using keyBy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ dependency-reduced-pom.xml
 .DS_Store
 *.log
 kubernets/config
+.project
+.classpath
+.factorypath
+bin/
+.settings/

--- a/audit-event-generator/src/main/scala/org/sunbird/job/auditevent/domain/Event.scala
+++ b/audit-event-generator/src/main/scala/org/sunbird/job/auditevent/domain/Event.scala
@@ -8,6 +8,8 @@ class Event(eventMap: java.util.Map[String, Any], partition: Int, offset: Long) 
   private val IMAGE_SUFFIX = ".img"
   private val jobName = "AuditEventGenerator"
 
+  def id: String = readOrDefault("nodeUniqueId", "")
+
   def operationType: String = readOrDefault("operationType", "")
 
   def nodeUniqueId: String = readOrDefault("nodeUniqueId", null)

--- a/audit-event-generator/src/main/scala/org/sunbird/job/auditevent/task/AuditEventGeneratorStreamTask.scala
+++ b/audit-event-generator/src/main/scala/org/sunbird/job/auditevent/task/AuditEventGeneratorStreamTask.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.util
 import com.typesafe.config.ConfigFactory
 import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
@@ -52,3 +53,7 @@ object AuditEventGeneratorStreamTask {
 }
 
 // $COVERAGE-ON$
+
+class AuditEventKeySelector extends KeySelector[Event, String] {
+  override def getKey(in: Event): String = in.id.replace(".img", "")
+}

--- a/audit-history-indexer/src/main/scala/org/sunbird/job/audithistory/domain/Event.scala
+++ b/audit-history-indexer/src/main/scala/org/sunbird/job/audithistory/domain/Event.scala
@@ -12,6 +12,8 @@ class Event(eventMap: java.util.Map[String, Any], partition: Int, offset: Long) 
 
   private val jobName = "AuditHistoryIndexer"
 
+  def id: String = readOrDefault("nodeUniqueId", "")
+
   def nodeType: String = readOrDefault("nodeType", "")
 
   def ets: Long = readOrDefault("ets", 0L)

--- a/metrics-data-transformer/src/main/scala/org/sunbird/job/metricstransformer/function/MetricsDataTransformerFunction.scala
+++ b/metrics-data-transformer/src/main/scala/org/sunbird/job/metricstransformer/function/MetricsDataTransformerFunction.scala
@@ -1,20 +1,19 @@
 package org.sunbird.job.metricstransformer.function
 
 import java.util
-
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.functions.ProcessFunction
-import org.sunbird.job.{BaseProcessFunction, Metrics}
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
+import org.sunbird.job.{BaseProcessKeyedFunction, Metrics}
 import org.sunbird.job.metricstransformer.domain.Event
 import org.sunbird.job.metricstransformer.service.MetricsDataTransformerService
 import org.sunbird.job.metricstransformer.task.MetricsDataTransformerConfig
-import org.sunbird.job.util.{ElasticSearchUtil, HttpUtil}
+import org.sunbird.job.util.HttpUtil
 
 class MetricsDataTransformerFunction(config: MetricsDataTransformerConfig, httpUtil: HttpUtil)
                             (implicit mapTypeInfo: TypeInformation[util.Map[String, Any]],
                              stringTypeInfo: TypeInformation[String])
-                            extends BaseProcessFunction[Event, String](config) with MetricsDataTransformerService {
+                            extends BaseProcessKeyedFunction[String, Event, String](config) with MetricsDataTransformerService {
 
   override def metricsList(): List[String] = {
     List(config.totalEventsCount, config.successEventCount, config.failedEventCount, config.skippedEventCount)
@@ -29,7 +28,7 @@ class MetricsDataTransformerFunction(config: MetricsDataTransformerConfig, httpU
   }
 
   override def processElement(event: Event,
-                              context: ProcessFunction[Event, String]#Context,
+                              context: KeyedProcessFunction[String, Event, String]#Context,
                               metrics: Metrics): Unit = {
     metrics.incCounter(config.totalEventsCount)
     val propertyMap = event.transactionData("properties").asInstanceOf[Map[String, AnyRef]]

--- a/search-indexer/src/main/scala/org/sunbird/job/searchindexer/functions/TransactionEventRouter.scala
+++ b/search-indexer/src/main/scala/org/sunbird/job/searchindexer/functions/TransactionEventRouter.scala
@@ -2,16 +2,16 @@ package org.sunbird.job.searchindexer.functions
 
 import com.google.gson.reflect.TypeToken
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.apache.flink.streaming.api.functions.{KeyedProcessFunction, ProcessFunction}
 import org.slf4j.LoggerFactory
 import org.sunbird.job.searchindexer.compositesearch.domain.Event
 import org.sunbird.job.searchindexer.task.SearchIndexerConfig
-import org.sunbird.job.{BaseProcessFunction, Metrics}
+import org.sunbird.job.{BaseProcessFunction, BaseProcessKeyedFunction, Metrics}
 
 import java.lang.reflect.Type
 
 class TransactionEventRouter(config: SearchIndexerConfig)
-  extends BaseProcessFunction[Event, String](config) {
+  extends BaseProcessKeyedFunction[String, Event, String](config) {
 
   private[this] val logger = LoggerFactory.getLogger(classOf[TransactionEventRouter])
   val mapType: Type = new TypeToken[java.util.Map[String, AnyRef]]() {}.getType
@@ -24,7 +24,7 @@ class TransactionEventRouter(config: SearchIndexerConfig)
     super.close()
   }
 
-  override def processElement(event: Event, context: ProcessFunction[Event, String]#Context, metrics: Metrics): Unit = {
+  override def processElement(event: Event, context: KeyedProcessFunction[String, Event, String]#Context, metrics: Metrics): Unit = {
     metrics.incCounter(config.totalEventsCount)
     if (event.validEvent(config.restrictObjectTypes)) {
       event.nodeType match {

--- a/search-indexer/src/main/scala/org/sunbird/job/searchindexer/functions/TransactionEventRouter.scala
+++ b/search-indexer/src/main/scala/org/sunbird/job/searchindexer/functions/TransactionEventRouter.scala
@@ -2,11 +2,11 @@ package org.sunbird.job.searchindexer.functions
 
 import com.google.gson.reflect.TypeToken
 import org.apache.flink.configuration.Configuration
-import org.apache.flink.streaming.api.functions.{KeyedProcessFunction, ProcessFunction}
+import org.apache.flink.streaming.api.functions.KeyedProcessFunction
 import org.slf4j.LoggerFactory
 import org.sunbird.job.searchindexer.compositesearch.domain.Event
 import org.sunbird.job.searchindexer.task.SearchIndexerConfig
-import org.sunbird.job.{BaseProcessFunction, BaseProcessKeyedFunction, Metrics}
+import org.sunbird.job.{BaseProcessKeyedFunction, Metrics}
 
 import java.lang.reflect.Type
 
@@ -45,7 +45,5 @@ class TransactionEventRouter(config: SearchIndexerConfig)
   override def metricsList(): List[String] = {
     List(config.totalEventsCount, config.skippedEventCount)
   }
-
-
 
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SC-1915" title="SC-1915" target="_blank"><img alt="Epic" src="https://project-sunbird.atlassian.net/images/icons/issuetypes/epic.svg" />SC-1915</a>  Migrate all samza jobs into flink
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->


The order of the events are important. We should push a specific object related all transaction events to single pipeline or process.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules