### PR TITLE
Issue SB-26671: Metrics Data Transform Job- error handling for content update API

### DIFF
--- a/metrics-data-transformer/src/main/resources/metrics-data-transformer.conf
+++ b/metrics-data-transformer/src/main/resources/metrics-data-transformer.conf
@@ -21,6 +21,6 @@ service {
 content_read_api = "/content/v3/read"
 content_update_api= "/content/v4/system/update"
 
-sourcing.update.api.response.code = ["404"]
+sourcing.update.api.response.error.code = ["404"]
 
 data.metrics = ["me_totalRatingsCount","me_averageRating","me_totalTimeSpentInSec","me_totalPlaySessionCount"]

--- a/metrics-data-transformer/src/main/resources/metrics-data-transformer.conf
+++ b/metrics-data-transformer/src/main/resources/metrics-data-transformer.conf
@@ -21,4 +21,6 @@ service {
 content_read_api = "/content/v3/read"
 content_update_api= "/content/v4/system/update"
 
+sourcing.update.api.response.code = ["404"]
+
 data.metrics = ["me_totalRatingsCount","me_averageRating","me_totalTimeSpentInSec","me_totalPlaySessionCount"]

--- a/metrics-data-transformer/src/main/scala/org/sunbird/job/metricstransformer/service/MetricsDataTransformerService.scala
+++ b/metrics-data-transformer/src/main/scala/org/sunbird/job/metricstransformer/service/MetricsDataTransformerService.scala
@@ -114,6 +114,7 @@ trait MetricsDataTransformerService {
       metrics.incCounter(config.successEventCount)
       true
     } else if (config.updateAPIErrorCodeList.contains(response.status.toString)) {
+      logger.error("Skipping The Event As Content Update API Response is: " + response.status + " For sourcing id: " + sourcingId)
       metrics.incCounter(config.skippedEventCount)
       true
     } else {

--- a/metrics-data-transformer/src/main/scala/org/sunbird/job/metricstransformer/service/MetricsDataTransformerService.scala
+++ b/metrics-data-transformer/src/main/scala/org/sunbird/job/metricstransformer/service/MetricsDataTransformerService.scala
@@ -44,9 +44,8 @@ trait MetricsDataTransformerService {
         if(hasOriginContent) {
           try {
             val channel = event.channel
-            updateContentMetrics(contentMetrics, sourcingId, channel)(config, httpUtil)
+            updateContentMetrics(contentMetrics, sourcingId, channel, metrics)(config, httpUtil)
             logger.info("Updated content metrics: " + identifier)
-            metrics.incCounter(config.successEventCount)
           } catch {
             case ex: Exception =>
               logger.error("Error while writing content metrics :: " + event.getJson + " :: ", ex)
@@ -95,7 +94,7 @@ trait MetricsDataTransformerService {
     }
   }
 
-  def updateContentMetrics(contentProperty: String, sourcingId: String, channel: String)(config: MetricsDataTransformerConfig, httpUtil: HttpUtil): Boolean = {
+  def updateContentMetrics(contentProperty: String, sourcingId: String, channel: String, metrics: Metrics)(config: MetricsDataTransformerConfig, httpUtil: HttpUtil): Boolean = {
     val updateUrl = config.lpURL + config.contentUpdate + "/" + sourcingId
     val contentMetrics = if (contentProperty.nonEmpty) contentProperty.substring(0, contentProperty.length - 1) else contentProperty
 
@@ -112,6 +111,10 @@ trait MetricsDataTransformerService {
     val headers = config.defaultHeaders ++ Map("X-Channel-Id" -> channel)
     val response: HTTPResponse = httpUtil.patch(updateUrl, request, headers)
     if (response.status == 200) {
+      metrics.incCounter(config.successEventCount)
+      true
+    } else if (config.updateAPIErrorCodeList.contains(response.status.toString)) {
+      metrics.incCounter(config.skippedEventCount)
       true
     } else {
       logger.error("Error while updating metrics for content : " + sourcingId + " :: " + response.body)

--- a/metrics-data-transformer/src/main/scala/org/sunbird/job/metricstransformer/task/MetricsDataTransformerConfig.scala
+++ b/metrics-data-transformer/src/main/scala/org/sunbird/job/metricstransformer/task/MetricsDataTransformerConfig.scala
@@ -24,6 +24,7 @@ class MetricsDataTransformerConfig(override val config: Config) extends BaseJobC
   val contentUpdate = config.getString("content_update_api")
 
   val defaultHeaders = Map[String, String] ("Content-Type" -> "application/json")
+  val updateAPIErrorCodeList = if(config.getStringList("sourcing.update.api.response.code").isEmpty) List("404").asInstanceOf[java.util.List[String]] else config.getStringList("sourcing.update.api.response.code")
 
   // Consumers
   val eventConsumer = "metrics-data-transformer-consumer"

--- a/metrics-data-transformer/src/main/scala/org/sunbird/job/metricstransformer/task/MetricsDataTransformerConfig.scala
+++ b/metrics-data-transformer/src/main/scala/org/sunbird/job/metricstransformer/task/MetricsDataTransformerConfig.scala
@@ -24,7 +24,7 @@ class MetricsDataTransformerConfig(override val config: Config) extends BaseJobC
   val contentUpdate = config.getString("content_update_api")
 
   val defaultHeaders = Map[String, String] ("Content-Type" -> "application/json")
-  val updateAPIErrorCodeList = if(config.getStringList("sourcing.update.api.response.code").isEmpty) List("404").asInstanceOf[java.util.List[String]] else config.getStringList("sourcing.update.api.response.code")
+  val updateAPIErrorCodeList = if(config.getStringList("sourcing.update.api.response.error.code").isEmpty) List("404").asInstanceOf[java.util.List[String]] else config.getStringList("sourcing.update.api.response.error.code")
 
   // Consumers
   val eventConsumer = "metrics-data-transformer-consumer"

--- a/metrics-data-transformer/src/main/scala/org/sunbird/job/metricstransformer/task/MetricsDataTransformerConfig.scala
+++ b/metrics-data-transformer/src/main/scala/org/sunbird/job/metricstransformer/task/MetricsDataTransformerConfig.scala
@@ -24,7 +24,7 @@ class MetricsDataTransformerConfig(override val config: Config) extends BaseJobC
   val contentUpdate = config.getString("content_update_api")
 
   val defaultHeaders = Map[String, String] ("Content-Type" -> "application/json")
-  val updateAPIErrorCodeList = if(config.getStringList("sourcing.update.api.response.error.code").isEmpty) List("404").asInstanceOf[java.util.List[String]] else config.getStringList("sourcing.update.api.response.error.code")
+  val updateAPIErrorCodeList = if(config.hasPath("sourcing.update.api.response.error.code")) config.getStringList("sourcing.update.api.response.error.code") else List("404").asInstanceOf[java.util.List[String]]
 
   // Consumers
   val eventConsumer = "metrics-data-transformer-consumer"

--- a/metrics-data-transformer/src/test/resources/test.conf
+++ b/metrics-data-transformer/src/test/resources/test.conf
@@ -21,6 +21,6 @@ service {
 content_read_api = "/content/v3/read"
 content_update_api= "/content/v4/system/update"
 
-sourcing.update.api.response.code = ["404"]
+sourcing.update.api.response.error.code = ["404"]
 
 data.metrics = ["me_totalRatingsCount","me_averageRating","me_totalTimeSpentInSec","me_totalPlaySessionCount"]

--- a/metrics-data-transformer/src/test/resources/test.conf
+++ b/metrics-data-transformer/src/test/resources/test.conf
@@ -21,4 +21,6 @@ service {
 content_read_api = "/content/v3/read"
 content_update_api= "/content/v4/system/update"
 
+sourcing.update.api.response.code = ["404"]
+
 data.metrics = ["me_totalRatingsCount","me_averageRating","me_totalTimeSpentInSec","me_totalPlaySessionCount"]

--- a/metrics-data-transformer/src/test/scala/org/sunbird/job/spec/service/MetricsDataTransformerServiceTestSpec.scala
+++ b/metrics-data-transformer/src/test/scala/org/sunbird/job/spec/service/MetricsDataTransformerServiceTestSpec.scala
@@ -174,4 +174,26 @@ class MetricsDataTransformerServiceTestSpec extends BaseTestSpec {
     }
   }
 
+  it should "skip event if response from sourcing update API not found" in {
+    val inputEvent: Event = new Event(JSONUtil.deserialize[util.Map[String, Any]](EventFixture.EVENT_1),0, 10)
+    val map = new ConcurrentHashMap[String, AtomicLong]()
+    map.put("skipped-events-count", new AtomicLong(0))
+    val metrics: Metrics = Metrics(map)
+
+    val metricList = Array("me_totalRatingsCount")
+    implicit val mockHttpUtil = mock[HttpUtil](Mockito.withSettings().serializable())
+
+    when(mockHttpUtil.get(ArgumentMatchers.contains("https://localhost:9000/action/content/v3/read/do_11309778227546521611171"), any())).thenReturn(HTTPResponse(200, """{"id":"api.v3.read.get","ver":"1.0","ts":"2020-08-07T15:56:47ZZ","params":{"resmsgid":"bbd98348-c70b-47bc-b9f1-396c5e803436","msgid":null,"err":null,"status":"successful","errmsg":null},"responseCode":"OK","result":{"content":{"parent":"do_123","origin":"do_119831368202241", "programId": "program123", "originData": {"identifier": "do_2133606182319800321377","repository": "https://dock.preprod.ntp.net.in/api/content/v1/read/do_2133606182319800321377"},"mediaType":"content","name":"APSWREIS-TGT2-Day5","identifier":"do_234","description":"Enter description for Collection","resourceType":"Collection","mimeType":"application/vnd.ekstep.content-collection","contentType":"Collection","language":["English"],"objectType":"Content","status":"Live","idealScreenSize":"normal","contentEncoding":"gzip","osId":"org.ekstep.quiz.app","contentDisposition":"inline","childNodes":["do_345"],"visibility":"Default","pkgVersion":2,"idealScreenDensity":"hdpi"}}}"""))
+    when(mockHttpUtil.get(ArgumentMatchers.contains("http://localhost/content/content/v3/read/do_119831368202241"), any())).thenReturn(HTTPResponse(200, """{"id":"api.v3.read.get","ver":"1.0","ts":"2020-08-07T15:56:47ZZ","params":{"resmsgid":"bbd98348-c70b-47bc-b9f1-396c5e803436","msgid":null,"err":null,"status":"successful","errmsg":null},"responseCode":"OK","result":{"content":{"parent":"do_11983136820224112","mediaType":"content","name":"APSWREIS-TGT2-Day5","identifier":"do_234","description":"Enter description for Collection","resourceType":"Collection","mimeType":"application/vnd.ekstep.content-collection","contentType":"Collection","language":["English"],"objectType":"Content","status":"Live","idealScreenSize":"normal","contentEncoding":"gzip","osId":"org.ekstep.quiz.app","contentDisposition":"inline","childNodes":["do_345"],"visibility":"Default","pkgVersion":2,"idealScreenDensity":"hdpi"}}}"""))
+    when(mockHttpUtil.patch(anyString(), any(), any())).thenReturn(HTTPResponse(404, """{"id":"api.content.system.update","ver":"4.0","ts":"2021-09-16T13:35:24ZZ","params":{"resmsgid":"cc879235-14d7-4815-b5cf-413ec0b0a1a7","msgid":null,"err":"CLIENT_ERROR","status":"failed","errmsg":"Validation Errors"},"responseCode":"CLIENT_ERROR","result":{"messages":["Metadata mimeType should be one of: [application/vnd.ekstep.ecml-archive]"]}}"""))
+
+    implicit val config = jobConfig
+    try {
+      metricsDataTransformer.processEvent(inputEvent, metrics, metricList)
+    } catch {
+      case ex: JobExecutionException =>
+        BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.skippedEventCount}").getValue() should be(1)
+    }
+  }
+
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-26671" title="SB-26671" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10304&avatarType=issuetype" />SB-26671</a>  Usage Details count is not updated under My Contents tab for contributors.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
https://project-sunbird.atlassian.net/browse/SB-26671

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules