### PR TITLE
Issue #SB-26796: FIx for content name too long for ECAR generation

### DIFF
--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/config/PublishConfig.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/config/PublishConfig.scala
@@ -9,6 +9,11 @@ class PublishConfig(override val config: Config, override val jobName: String) e
 		if(config.hasPath(key)) config.getString(key) else default
 	}
 
+	def getInt(key: String, default: Int): Int = {
+		if(config.hasPath(key)) config.getInt(key) else default
+	}
+
+
 	def getBoolean(key: String, default: Boolean): Boolean = {
 		if(config.hasPath(key)) config.getBoolean(key) else default
 	}

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/ObjectBundle.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/ObjectBundle.scala
@@ -27,9 +27,9 @@ trait ObjectBundle {
 	private val hierarchyFileName = "hierarchy.json"
 	private val hierarchyVersion = "1.0"
 	val excludeBundleMeta = List("screenshots", "posterImage", "index", "depth")
-	private val maxAllowedContentName = 150
 
-	def getBundleFileName(identifier: String, metadata: Map[String, AnyRef], pkgType: String) = {
+	def getBundleFileName(identifier: String, metadata: Map[String, AnyRef], pkgType: String)(implicit ec: ExecutionContext, config: PublishConfig) = {
+		val maxAllowedContentName = config.getString("max_allowed_content_name", "150").toInt
 		val contentName = if(metadata.getOrElse("name", "").asInstanceOf[String].length>maxAllowedContentName) metadata.getOrElse("name", "").asInstanceOf[String].substring(0,maxAllowedContentName) else metadata.getOrElse("name", "").asInstanceOf[String]
 		Slug.makeSlug(contentName, true) + "_" + System.currentTimeMillis() + "_" + identifier + "_" + metadata.getOrElse("pkgVersion", "") + (if (StringUtils.equals(EcarPackageType.FULL.toString, pkgType)) ".ecar" else "_" + pkgType + ".ecar")
 	}

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/ObjectBundle.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/ObjectBundle.scala
@@ -28,8 +28,8 @@ trait ObjectBundle {
 	private val hierarchyVersion = "1.0"
 	val excludeBundleMeta = List("screenshots", "posterImage", "index", "depth")
 
-	def getBundleFileName(identifier: String, metadata: Map[String, AnyRef], pkgType: String)(implicit ec: ExecutionContext, config: PublishConfig) = {
-		val maxAllowedContentName = config.getString("max_allowed_content_name", "150").toInt
+	def getBundleFileName(identifier: String, metadata: Map[String, AnyRef], pkgType: String)(implicit config: PublishConfig): String = {
+		val maxAllowedContentName = config.getInt("max_allowed_content_name", 120)
 		val contentName = if(metadata.getOrElse("name", "").asInstanceOf[String].length>maxAllowedContentName) metadata.getOrElse("name", "").asInstanceOf[String].substring(0,maxAllowedContentName) else metadata.getOrElse("name", "").asInstanceOf[String]
 		Slug.makeSlug(contentName, true) + "_" + System.currentTimeMillis() + "_" + identifier + "_" + metadata.getOrElse("pkgVersion", "") + (if (StringUtils.equals(EcarPackageType.FULL.toString, pkgType)) ".ecar" else "_" + pkgType + ".ecar")
 	}

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/ObjectBundle.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/ObjectBundle.scala
@@ -23,14 +23,15 @@ trait ObjectBundle {
 	private val onlineMimeTypes = List("video/youtube", "video/x-youtube", "text/x-url")
 	private val bundleLocation: String = "/tmp"
 	private val defaultManifestVersion = "1.2"
-	private val cloudBundleFolder = "ecar_files"
 	private val manifestFileName = "manifest.json"
 	private val hierarchyFileName = "hierarchy.json"
 	private val hierarchyVersion = "1.0"
 	val excludeBundleMeta = List("screenshots", "posterImage", "index", "depth")
+	private val maxAllowedContentName = 150
 
 	def getBundleFileName(identifier: String, metadata: Map[String, AnyRef], pkgType: String) = {
-		Slug.makeSlug(metadata.getOrElse("name", "").asInstanceOf[String], true) + "_" + System.currentTimeMillis() + "_" + identifier + "_" + metadata.getOrElse("pkgVersion", "") + (if (StringUtils.equals(EcarPackageType.FULL.toString, pkgType)) ".ecar" else "_" + pkgType + ".ecar")
+		val contentName = if(metadata.getOrElse("name", "").asInstanceOf[String].length>maxAllowedContentName) metadata.getOrElse("name", "").asInstanceOf[String].substring(0,maxAllowedContentName) else metadata.getOrElse("name", "").asInstanceOf[String]
+		Slug.makeSlug(contentName, true) + "_" + System.currentTimeMillis() + "_" + identifier + "_" + metadata.getOrElse("pkgVersion", "") + (if (StringUtils.equals(EcarPackageType.FULL.toString, pkgType)) ".ecar" else "_" + pkgType + ".ecar")
 	}
 
 	def getManifestData(objIdentifier: String, pkgType: String, objList: List[Map[String, AnyRef]])(implicit defCache: DefinitionCache, defConfig: DefinitionConfig): (List[Map[String, AnyRef]], List[Map[AnyRef, String]]) = {

--- a/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/spec/ObjectBundleSpec.scala
+++ b/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/spec/ObjectBundleSpec.scala
@@ -1,10 +1,12 @@
 package org.sunbird.job.publish.spec
 
+import com.typesafe.config.{Config, ConfigFactory}
 import org.apache.commons.lang3.StringUtils
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
+import org.sunbird.job.publish.config.PublishConfig
 import org.sunbird.job.publish.core.ObjectData
-import org.sunbird.job.publish.helpers.ObjectBundle
+import org.sunbird.job.publish.helpers.{EcarPackageType, ObjectBundle}
 import org.sunbird.job.util.HttpUtil
 
 class ObjectBundleSpec extends FlatSpec with BeforeAndAfterAll with Matchers with MockitoSugar {
@@ -36,6 +38,15 @@ class ObjectBundleSpec extends FlatSpec with BeforeAndAfterAll with Matchers wit
 	"isOnline" should "return false for invalid input" in {
 		val obj = new TestObjectBundle
 		obj.isOnline("application/vnd", "inline") should be(false)
+	}
+
+	"getBundleFileName" should "return file name with less than 250 characters" in {
+		val config: Config = ConfigFactory.load("test.conf").withFallback(ConfigFactory.systemEnvironment())
+		implicit val publishConfig: PublishConfig = new PublishConfig(config, "")
+		val maxAllowedContentName = publishConfig.getInt("max_allowed_content_name", 120)
+		val obj = new TestObjectBundle
+		val ecarName = obj.getBundleFileName("do_3133687719874150401162",Map("name" -> "6.10_ମାଂସପେଶୀ, ରକ୍ତ ସଂଚାଳନ ଓ ଶ୍ୱସନ ସଂସ୍ଥାନ ଉପରେ ଶାରୀରିକ କାର୍ଯ୍ୟ, ଖେଳ, କ୍ରୀଡା ଓ ଯୋଗର ପ୍ରଭାବ-eng_effects_of_physical_activities_games_sports_and_yoga_on_muscular_circulatory_and_respiratory_systems"), "SPINE")
+		(ecarName.length<(maxAllowedContentName+65)) should be(true)
 	}
 
 	"getHierarchyFile" should "return valid file" in {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-26796" title="SB-26796" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10303&avatarType=issuetype" />SB-26796</a>  Content Publish flink job fix: Ecar manifest file have wrong identifier as do_id.img
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Issue #SB-26796: FIx for content name too long for ECAR generation

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules