### PR TITLE
Issue #SB-27794 fix: Publishing error when same content is added multiple times

### DIFF
--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/ObjectBundle.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/ObjectBundle.scala
@@ -152,10 +152,12 @@ trait ObjectBundle {
     try {
       files.foreach(file => {
         val fileName = getFileName(file)
-        zipOutputStream.putNextEntry(new ZipEntry(fileName))
-        val fileInputStream = new FileInputStream(file)
-        IOUtils.copy(fileInputStream, zipOutputStream)
-        zipOutputStream.closeEntry()
+        try {
+          zipOutputStream.putNextEntry(new ZipEntry(fileName))
+          val fileInputStream = new FileInputStream(file)
+          IOUtils.copy(fileInputStream, zipOutputStream)
+          zipOutputStream.closeEntry()
+        } catch { case ze:java.util.zip.ZipException => logger.info(ze.getMessage) }
       })
 
       if (zipOutputStream != null) {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-27794" title="SB-27794" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10304&avatarType=issuetype" />SB-27794</a>  Textbook is not getting published with error ecar generation
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Issue #SB-27794 fix: Publishing error when same content is added multiple times to collection

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran Unit Tests

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules