### PR TITLE
Issue #SB-27987 fix: TB QR code removal not reflecting

### DIFF
--- a/publish-pipeline/content-publish/src/test/scala/org/sunbird/job/publish/helpers/spec/CollectionPublisherSpec.scala
+++ b/publish-pipeline/content-publish/src/test/scala/org/sunbird/job/publish/helpers/spec/CollectionPublisherSpec.scala
@@ -145,8 +145,10 @@ class CollectionPublisherSpec extends FlatSpec with BeforeAndAfterAll with Match
     val do_113405023736455168110Json = """{"identifier":"do_113405023736455168110","graph_id":"domain","node_id":0,"collections":["do_11340096293585715212"],"objectType":"Collection","nodeType":"DATA_NODE"}"""
     when(mockElasticUtil.getDocumentAsString("do_113405023736455168110")).thenReturn(do_113405023736455168110Json)
 
+    val publishedCollectionNodeMetadataObj: Map[String,AnyRef] = ScalaJsonUtil.deserialize[Map[String,AnyRef]](publishedCollectionNodeMetadata)
+    val data = new ObjectData("do_123", publishedCollectionNodeMetadataObj, Some(Map.empty[String, AnyRef]))
     val syncChildrenData = ScalaJsonUtil.deserialize[List[Map[String, AnyRef]]](publishedChildrenData)
-    val messages: Map[String, Map[String, AnyRef]] = new TestCollectionPublisher().syncNodes(syncChildrenData, List.empty)(mockElasticUtil, mockNeo4JUtil, cassandraUtil, readerConfig, definition, jobConfig)
+    val messages: Map[String, Map[String, AnyRef]] = new TestCollectionPublisher().syncNodes(data, syncChildrenData, List.empty)(mockElasticUtil, mockNeo4JUtil, cassandraUtil, readerConfig, definition, jobConfig)
 
     assert(messages != null && messages.size > 0)
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-27987" title="SB-27987" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10304&avatarType=issuetype" />SB-27987</a>  Post removing the qr code from the published book and publishing again, still creator is able to see the removed qr code in live textbook
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran Unit Tests

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules