### PR TITLE
Publish pipeline interactive video changes

### DIFF
--- a/jobs-core/src/main/resources/base-config.conf
+++ b/jobs-core/src/main/resources/base-config.conf
@@ -1,6 +1,7 @@
 kafka {
   broker-servers = "localhost:9092"
   zookeeper = "localhost:2181"
+  urls="localhost:9092"
 }
 
 job {

--- a/jobs-core/src/main/scala/org/sunbird/job/domain/event/PublishEvent.java
+++ b/jobs-core/src/main/scala/org/sunbird/job/domain/event/PublishEvent.java
@@ -1,0 +1,73 @@
+package org.sunbird.job.domain.event;
+
+import java.util.Map;
+
+public class PublishEvent {
+
+
+    private String eid;
+    private long ets;
+    private String mid;
+    private Map<String, Object> actor;
+    private Map<String, Object> context;
+    private Map<String, Object> object;
+    private Map<String, Object> edata;
+
+
+    public String getEid() {
+        return eid;
+    }
+
+    public void setEid(String eid) {
+        this.eid = eid;
+    }
+
+    public long getEts() {
+        return ets;
+    }
+
+    public void setEts(long ets) {
+        this.ets = ets;
+    }
+
+    public String getMid() {
+        return mid;
+    }
+
+    public void setMid(String mid) {
+        this.mid = mid;
+    }
+
+    public Map<String, Object> getActor() {
+        return actor;
+    }
+
+    public void setActor(Map<String, Object> actor) {
+        this.actor = actor;
+    }
+
+    public Map<String, Object> getContext() {
+        return context;
+    }
+
+    public void setContext(Map<String, Object> context) {
+        this.context = context;
+    }
+
+    public Map<String, Object> getObject() {
+        return object;
+    }
+
+    public void setObject(Map<String, Object> object) {
+        this.object = object;
+    }
+
+    public Map<String, Object> getEdata() {
+        return edata;
+    }
+
+    public void setEdata(Map<String, Object> edata) {
+        this.edata = edata;
+    }
+
+}

--- a/jobs-core/src/main/scala/org/sunbird/job/util/FileUtils.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/FileUtils.scala
@@ -9,6 +9,7 @@ import java.net.{HttpURLConnection, URL}
 import java.nio.file.{Files, Path, Paths}
 import java.util.zip.{ZipEntry, ZipFile, ZipOutputStream}
 import scala.collection.JavaConverters._
+import scala.collection.mutable.ListBuffer
 
 object FileUtils {
 
@@ -146,6 +147,23 @@ object FileUtils {
         logger.error("Error! Something Went Wrong While Creating the ZIP File: " + e.getMessage, e)
         throw new Exception("Something Went Wrong While Creating the ZIP File", e)
     } finally if (zos != null) zos.close()
+  }
+  
+  def extractFiles(file: File, basePath: String): List[File]  = {
+    var list : ListBuffer[File] = new ListBuffer();
+    val zipFile = new ZipFile(file)
+    for (entry <- zipFile.entries().asScala) {
+      val path = Paths.get(basePath + File.separator + entry.getName)
+      if (entry.isDirectory) Files.createDirectories(path)
+      else {
+        Files.createDirectories(path.getParent)
+        Files.copy(zipFile.getInputStream(entry), path)
+        val file = new File(basePath + File.separator + entry.getName)
+        list += file;
+      }
+    }
+
+    list.toList
   }
 }
 

--- a/jobs-core/src/main/scala/org/sunbird/job/util/KafkaClientUtil.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/KafkaClientUtil.scala
@@ -1,0 +1,60 @@
+package org.sunbird.job.util
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, KafkaConsumer}
+import org.apache.kafka.clients.producer.{KafkaProducer, Producer, ProducerConfig, ProducerRecord}
+import org.apache.kafka.common.serialization.{LongDeserializer, LongSerializer, StringDeserializer, StringSerializer}
+import org.neo4j.driver.v1.exceptions.ClientException
+
+import java.util.Properties
+
+
+class KafkaClientUtil {
+	val config: Config = ConfigFactory.load("base-config.conf").withFallback(ConfigFactory.systemEnvironment())
+	private val BOOTSTRAP_SERVERS = config.getString("kafka.urls")
+	private val producer = createProducer()
+	private val consumer = createConsumer()
+
+	protected def getProducer: Producer[Long, String] = producer
+	protected def getConsumer: Consumer[Long, String] = consumer
+
+	@throws[Exception]
+	def send(event: String, topic: String): Unit = {
+//		if (!config.getBoolean("kafka.topic.send.enable")) return
+		if (validate(topic))
+			getProducer.send(new ProducerRecord[Long, String](topic, event))
+		else {
+			println("Topic with name: " + topic + ", does not exists.")
+			throw new ClientException("TOPIC_NOT_FOUND_EXCEPTION", "Topic with name: " + topic + ", does not exists.")
+
+		}
+	}
+
+	@throws[Exception]
+	def validate(topic: String): Boolean = {
+		val topics = getConsumer.listTopics
+		topics.keySet.contains(topic)
+	}
+
+	private def createProducer(): KafkaProducer[Long, String] = {
+		new KafkaProducer[Long, String](new Properties() {
+			{
+				put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
+				put(ProducerConfig.CLIENT_ID_CONFIG, "KafkaClientProducer")
+				put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[LongSerializer].getName)
+				put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, classOf[StringSerializer].getName)
+			}
+		})
+	}
+
+	private def createConsumer(): KafkaConsumer[Long, String] = {
+		new KafkaConsumer[Long, String](new Properties() {
+			{
+				put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS)
+				put(ConsumerConfig.CLIENT_ID_CONFIG, "KafkaClientConsumer")
+				put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, classOf[LongDeserializer].getName)
+				put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, classOf[StringDeserializer].getName)
+			}
+		})
+	}
+}

--- a/jobs-core/src/main/scala/org/sunbird/job/util/OntologyEngineContext.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/OntologyEngineContext.scala
@@ -1,0 +1,17 @@
+package org.sunbird.job.util
+
+;
+
+class OntologyEngineContext {
+    private val kfClient = new KafkaClientUtil
+
+    def extStoreDB = {
+
+    }
+
+    def redis = {
+
+    }
+
+    def kafkaClient = kfClient
+}

--- a/jobs-core/src/test/scala/org/sunbird/spec/KafkaBaseTest.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/KafkaBaseTest.scala
@@ -1,0 +1,31 @@
+package org.sunbird.spec
+
+
+import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+class KafkaBaseTest extends FlatSpec with Matchers with BeforeAndAfterAll with EmbeddedKafka {
+
+	implicit val config = EmbeddedKafkaConfig(kafkaPort = 9092)
+
+	override def beforeAll(): Unit = {
+		try {
+			EmbeddedKafka.start()
+		} catch {
+			case e: Exception => e.printStackTrace()
+		}
+	}
+
+	override def afterAll(): Unit = {
+		try {
+			EmbeddedKafka.stop()
+		} catch {
+			case e: Exception => e.printStackTrace()
+		}
+	}
+
+	def createTopic(topicName: String): Unit = {
+
+		EmbeddedKafka.createCustomTopic(topicName)
+	}
+}

--- a/jobs-core/src/test/scala/org/sunbird/spec/KafkaClientSpec.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/KafkaClientSpec.scala
@@ -1,0 +1,41 @@
+package org.sunbird.spec
+
+import org.neo4j.driver.v1.exceptions.ClientException
+import org.sunbird.job.util.KafkaClientUtil
+
+class KafkaClientSpec extends KafkaBaseTest {
+
+//  "validate with valid topic name" should "return true" in {
+//    createTopic("test.topic1")
+//    val client = new KafkaClientUtil
+//    val result = client.validate("test.topic1")
+//    assert(result)
+//  }
+
+  "validate with invalid topic name" should "return false" in {
+    val client = new KafkaClientUtil
+    val result = client.validate("test.topic4")
+    assert(!result)
+  }
+
+//  "send with valid topic name" should "send the message successfully to the topic" in {
+//    val event = "{\"eid\":\"BE_JOB_REQUEST\",\"ets\":1546931576000,\"mid\":\"LP.1546931576000.b3fb188d-d6fe-431e-b528-da3780c710a8\",\"actor\":{\"id\":\"learning-service\",\"type\":\"System\"},\"context\":{\"pdata\":{\"ver\":\"1.0\",\"id\":\"org.ekstep.platform\"},\"channel\":\"in.ekstep\",\"env\":\"dev\"},\"object\":{\"ver\":1.0,\"id\":\"do_1234\"},\"edata\":{\"action\":\"link_dialcode\",\"iteration\":1,\"graphId\":\"domain\",\"contentType\":\"Course\",\"objectType\":\"Content\"}}"
+//    val topic = "test.topic3"
+//    createTopic(topic)
+//    val client = new KafkaClientUtil
+//    client.send(event, topic)
+//    consumeFirstStringMessageFrom(topic) shouldBe event
+//  }
+
+  "send with invalid topic name" should "throw client exception" in {
+    val event = "{\"eid\":\"BE_JOB_REQUEST\",\"ets\":1546931576000,\"mid\":\"LP.1546931576000.b3fb188d-d6fe-431e-b528-da3780c710a8\",\"actor\":{\"id\":\"learning-service\",\"type\":\"System\"},\"context\":{\"pdata\":{\"ver\":\"1.0\",\"id\":\"org.ekstep.platform\"},\"channel\":\"in.ekstep\",\"env\":\"dev\"},\"object\":{\"ver\":1.0,\"id\":\"do_1234\"},\"edata\":{\"action\":\"link_dialcode\",\"iteration\":1,\"graphId\":\"domain\",\"contentType\":\"Course\",\"objectType\":\"Content\"}}"
+    val topic = "test.topic4"
+    val client = new KafkaClientUtil
+    val exception = intercept[ClientException] {
+      client.send(event, topic)
+    }
+    exception.getMessage shouldEqual "Topic with name: " + topic + ", does not exists."
+  }
+
+}
+

--- a/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/ContentPublishFunction.scala
+++ b/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/ContentPublishFunction.scala
@@ -2,6 +2,7 @@ package org.sunbird.job.content.function
 
 import akka.dispatch.ExecutionContexts
 import com.google.gson.reflect.TypeToken
+import org.apache.commons.lang3.StringUtils
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.functions.ProcessFunction
@@ -16,7 +17,7 @@ import org.sunbird.job.exception.InvalidInputException
 import org.sunbird.job.helper.FailedEventHelper
 import org.sunbird.job.publish.core.{DefinitionConfig, ExtDataConfig, ObjectData}
 import org.sunbird.job.publish.helpers.EcarPackageType
-import org.sunbird.job.util.{CassandraUtil, CloudStorageUtil, HttpUtil, Neo4JUtil}
+import org.sunbird.job.util.{CassandraUtil, CloudStorageUtil, HttpUtil, JSONUtil, Neo4JUtil}
 import org.sunbird.job.{BaseProcessFunction, Metrics}
 
 import java.lang.reflect.Type
@@ -85,7 +86,8 @@ class ContentPublishFunction(config: ContentPublishConfig, httpUtil: HttpUtil,
           // Clear redis cache
           cache.del(data.identifier)
           val enrichedObj = enrichObject(ecmlVerifiedObj)(neo4JUtil, cassandraUtil, readerConfig, cloudStorageUtil, config, definitionCache, definitionConfig)
-          val objWithEcar = getObjectWithEcar(enrichedObj, if (enrichedObj.getString("contentDisposition", "").equalsIgnoreCase("online-only")) List(EcarPackageType.SPINE.toString) else pkgTypes)(ec, cloudStorageUtil, config, definitionCache, definitionConfig, httpUtil)
+          val objectWithPublishChain = getObjectWithPublishChain(data, enrichedObj)
+          val objWithEcar = getObjectWithEcar(objectWithPublishChain, if (enrichedObj.getString("contentDisposition", "").equalsIgnoreCase("online-only")) List(EcarPackageType.SPINE.toString) else pkgTypes)(ec, cloudStorageUtil, config, definitionCache, definitionConfig, httpUtil)
           logger.info("Ecar generation done for Content: " + objWithEcar.identifier)
           saveOnSuccess(objWithEcar)(neo4JUtil, cassandraUtil, readerConfig, definitionCache, definitionConfig)
           pushStreamingUrlEvent(enrichedObj, context)(metrics)
@@ -160,5 +162,16 @@ class ContentPublishFunction(config: ContentPublishConfig, httpUtil: HttpUtil,
     val failedEvent = if (error == null) getFailedEvent(event.jobName, event.getMap(), errorMessage) else getFailedEvent(event.jobName, event.getMap(), error)
     context.output(config.failedEventOutTag, failedEvent)
     metrics.incCounter(config.contentPublishFailedEventCount)
+  }
+
+  private def getObjectWithPublishChain(data: Event, obj: ObjectData) : ObjectData = {
+    if (StringUtils.isNotEmpty(data.publishChainString)) {
+      val publishChainEvent: Map[String, AnyRef] = JSONUtil.deserialize[Map[String, AnyRef]](data.publishChainString)
+      val eData: Map[String, AnyRef] = publishChainEvent.getOrElse("eData", Map[String, AnyRef]()).asInstanceOf[Map[String, AnyRef]]
+      val publishChain: List[Map[String, AnyRef]] = eData.getOrElse("publishchain", List[Map[String, AnyRef]]()).asInstanceOf[List[Map[String, AnyRef]]]
+      return new ObjectData(obj.identifier, obj.metadata ++ Map("publishchain" -> publishChain), obj.extData, obj.hierarchy)
+    }
+    else obj
+
   }
 }

--- a/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/publish/domain/Event.scala
+++ b/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/publish/domain/Event.scala
@@ -25,6 +25,8 @@ class Event(eventMap: java.util.Map[String, Any], partition: Int, offset: Long) 
 
   def lastPublishedBy: String = readOrDefault[String]("edata.metadata.lastPublishedBy", "")
 
+  def publishChainString : String = readOrDefault[String]("edata.metadata.publishChainString", "");
+
   def pkgVersion: Double = {
     val pkgVersion: Number = readOrDefault[Number]("edata.metadata.pkgVersion", 0)
     pkgVersion.doubleValue()

--- a/publish-pipeline/publish-core/pom.xml
+++ b/publish-pipeline/publish-core/pom.xml
@@ -21,9 +21,54 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils_${scala.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-runtime_${scala.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java_${scala.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
             <groupId>org.sunbird</groupId>
             <artifactId>jobs-core</artifactId>
             <version>1.0.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.sunbird</groupId>
+            <artifactId>jobs-core</artifactId>
+            <version>1.0.0</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>jackson-module-scala_2.12</artifactId>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.cassandraunit</groupId>
+            <artifactId>cassandra-unit</artifactId>
+            <version>3.11.2.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.scalatest</groupId>

--- a/publish-pipeline/publish-core/src/main/resources/publish-core.conf
+++ b/publish-pipeline/publish-core/src/main/resources/publish-core.conf
@@ -1,0 +1,20 @@
+include "base-config.conf"
+
+job {
+  env = "sunbirddev"
+}
+
+kafka {
+  input.topic = "sunbirddev.publishchain.publish.request"
+  post_publish.topic = "sunbirddev.content.postpublish.request"
+  groupId = "local-questionset-publish-group"
+  event.questionset.topic = "sunbirddev.assessment.publish.request"
+  event.content.topic = "sunbirddev.publish.job.request"
+}
+
+task {
+  consumer.parallelism = 1
+  parallelism = 1
+  router.parallelism = 1
+}
+

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/core/Event.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/core/Event.scala
@@ -1,0 +1,42 @@
+package org.sunbird.job.publish.core
+
+import org.apache.commons.lang3.StringUtils
+import org.sunbird.job.domain.reader.JobRequest
+
+class Event(eventMap: java.util.Map[String, Any], partition: Int, offset: Long) extends JobRequest(eventMap, partition, offset) {
+
+	private val jobName = "chain-publish"
+
+	private val objectTypes = List("Question", "QuestionImage", "QuestionSet", "QuestionSetImage")
+	private val mimeTypes = List("application/vnd.sunbird.question", "application/vnd.sunbird.questionset")
+
+	def eData: Map[String, AnyRef] = readOrDefault("edata", Map[String, AnyRef]())
+
+	def context: Map[String, AnyRef] = readOrDefault("context", Map[String, AnyRef]())
+
+	def obj: Map[String, AnyRef] = readOrDefault("object",Map[String, AnyRef]())
+
+	def action: String = readOrDefault[String]("edata.action", "")
+
+	def publishType: String = readOrDefault[String]("edata.publish_type", "")
+
+	def channel : String = readOrDefault[String]("context.channel", "");
+
+	def versionkey : String = readOrDefault[String]("object.ver", "");
+
+	def objectIdentifier : String = readOrDefault[String]("object.id", "");
+
+	def publishChain : List[Map[String, AnyRef]]  = readOrDefault("edata.publishchain",List[Map[String, AnyRef]]()).map(m => m.toMap).toList
+
+	def publishChainString : String = readOrDefault[String]("edata.metadata.publishChainString", "");
+
+	def pkgVersion: Double = {
+    val pkgVersion = readOrDefault[Int]("edata.metadata.pkgVersion", 0)
+    pkgVersion.toDouble
+  }
+
+
+	def validPublishChainEvent(): Boolean = {
+		(StringUtils.equals("publishchain", action) && !publishChain.isEmpty)
+	}
+}

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/core/Models.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/core/Models.scala
@@ -19,3 +19,5 @@ case class ExtDataConfig(keyspace: String, table: String, primaryKey: List[Strin
 case class DefinitionConfig(supportedVersion: Map[String, AnyRef], basePath: String)
 
 case class ObjectExtData(data: Option[Map[String, AnyRef]] = None, hierarchy: Option[Map[String, AnyRef]] = None)
+
+case class PublishMetadata(identifier: String, pkgVersion: Double, publishType: String,eData:Map[String, AnyRef],context:Map[String, AnyRef],obj:Map[String, AnyRef],publishChain: List[Map[String, AnyRef]])

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/function/PublishCoreFunction.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/function/PublishCoreFunction.scala
@@ -1,0 +1,70 @@
+package org.sunbird.job.publish.function
+
+import com.google.gson.reflect.TypeToken
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.slf4j.LoggerFactory
+import org.sunbird.job.domain.`object`.DefinitionCache
+import org.sunbird.job.publish.core.{DefinitionConfig, PublishMetadata}
+import org.sunbird.job.publish.helpers.{EcarPackageType, EventGenerator}
+import org.sunbird.job.publish.task.PublishCoreConfig
+import org.sunbird.job.util.{CassandraUtil, CloudStorageUtil, HttpUtil, Neo4JUtil, OntologyEngineContext}
+import org.sunbird.job.{BaseProcessFunction, Metrics}
+
+import java.lang.reflect.Type
+import scala.concurrent.ExecutionContext
+
+class PublishCoreFunction(config: PublishCoreConfig, httpUtil: HttpUtil,
+                          @transient var neo4JUtil: Neo4JUtil = null,
+                          @transient var cassandraUtil: CassandraUtil = null,
+                          @transient var cloudStorageUtil: CloudStorageUtil = null,
+                          @transient var definitionCache: DefinitionCache = null,
+                          @transient var definitionConfig: DefinitionConfig = null)
+                         (implicit val stringTypeInfo: TypeInformation[String])
+  extends BaseProcessFunction[PublishMetadata, String](config)   {
+
+  private[this] val logger = LoggerFactory.getLogger(classOf[PublishCoreFunction])
+  val mapType: Type = new TypeToken[java.util.Map[String, AnyRef]]() {}.getType
+
+  @transient var ec: ExecutionContext = _
+  private val pkgTypes = List(EcarPackageType.FULL.toString, EcarPackageType.ONLINE.toString)
+
+  override def open(parameters: Configuration): Unit = {
+    super.open(parameters)
+  }
+
+  override def metricsList(): List[String] = {
+    List(config.publishChainEventCount, config.publishChainSuccessEventCount, config.publishChainFailedEventCount)
+  }
+
+  override def close(): Unit = {
+    super.close()
+    cassandraUtil.close()
+  }
+
+
+
+  override def processElement(publishMetadata: PublishMetadata, context: ProcessFunction[PublishMetadata, String]#Context, metrics: Metrics): Unit = {
+    implicit val oec = new OntologyEngineContext()
+    for( publishChainEvent : Map[String, AnyRef] <- publishMetadata.publishChain){
+      logger.info("PublishEventRouter :: Sending Publish Chain For Publish Having Identifier: " + publishChainEvent.getOrElse("identifier", ""))
+
+      if(publishChainEvent.getOrElse("state","").equals("Processing")) {
+        publishChainEvent.getOrElse("objectType","") match {
+          case "Content" | "ContentImage" => {
+            EventGenerator.pushPublishEvent(publishChainEvent,publishMetadata,config.contentTopic,"content-publish")
+            return
+          }
+          case "QuestionSet" | "QuestionSetImage" => {
+            EventGenerator.pushPublishEvent(publishChainEvent,publishMetadata,config.questionSetTopic,"questionset-publish")
+            return
+          }
+          case _ => {
+            logger.info("Invalid object type in publish chain events for identifier : " + publishChainEvent.getOrElse("identifier", ""))
+          }
+        }
+      }
+    }
+  }
+}

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/function/PublishEventRouter.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/function/PublishEventRouter.scala
@@ -1,0 +1,41 @@
+package org.sunbird.job.publish.function
+
+import com.google.gson.reflect.TypeToken
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.ProcessFunction
+import org.slf4j.LoggerFactory
+import org.sunbird.job.publish.core.{Event, PublishMetadata}
+import org.sunbird.job.publish.task.PublishCoreConfig
+import org.sunbird.job.{BaseProcessFunction, Metrics}
+
+import java.lang.reflect.Type
+
+class PublishEventRouter (config: PublishCoreConfig)  extends BaseProcessFunction[Event, String](config) {
+
+
+  private[this] val logger = LoggerFactory.getLogger(classOf[PublishEventRouter])
+  val mapType: Type = new TypeToken[java.util.Map[String, AnyRef]]() {}.getType
+
+  override def open(parameters: Configuration): Unit = {
+    super.open(parameters)
+  }
+
+  override def close(): Unit = {
+    super.close()
+  }
+
+  override def metricsList(): List[String] = {
+    List(config.skippedEventCount, config.totalEventsCount)
+  }
+
+  override def processElement(event: Event, context: ProcessFunction[Event, String]#Context, metrics: Metrics): Unit = {
+    metrics.incCounter(config.totalEventsCount)
+    if(event.validPublishChainEvent()) {
+      context.output(config.publishChainOutTag, PublishMetadata(event.objectIdentifier, event.pkgVersion, event.publishType,event.eData,event.context,event.obj,event.publishChain))
+    }
+    else {
+      logger.warn("Event skipped for identifier: " + event.objectIdentifier)
+      metrics.incCounter(config.skippedEventCount)
+    }
+  }
+}

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/EventGenerator.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/EventGenerator.scala
@@ -1,0 +1,105 @@
+package org.sunbird.job.publish.helpers
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.scala.DefaultScalaModule
+import org.apache.commons.lang3.StringUtils
+import org.neo4j.driver.v1.exceptions.ClientException
+import org.slf4j.LoggerFactory
+import org.sunbird.job.domain.event.PublishEvent
+import org.sunbird.job.publish.core.PublishMetadata
+import org.sunbird.job.util.{JSONUtil, OntologyEngineContext}
+
+import java.util
+import java.util.UUID
+import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
+
+object EventGenerator {
+  private val mapper = new ObjectMapper
+  private val beJobRequesteventId = "BE_JOB_REQUEST";
+  private val telemetryEventLogger = LoggerFactory.getLogger("TelemetryEventLogger")
+  private val iteration = "1"
+
+  @throws[Exception]
+  def pushPublishEvent(publishChainEvent: Map[String, AnyRef], publishMetadata:PublishMetadata, inputTopic: String, actorId:String)(implicit oec: OntologyEngineContext): Unit = {
+    val publishChainEventMap : scala.collection.mutable.Map[String, AnyRef]= collection.mutable.Map(publishChainEvent.toSeq: _*)
+    val (actor, context, objData, eData) = generatePublishEventMetadata(publishChainEventMap,publishMetadata,actorId)
+    val beJobRequestEvent: String = logInstructionEvent(actor, context, objData, eData)
+   if (StringUtils.isBlank(beJobRequestEvent)) throw new ClientException("BE_JOB_REQUEST_EXCEPTION", "Event is not generated properly.")
+    try {
+      oec.kafkaClient.send(beJobRequestEvent, inputTopic)
+    }catch{
+      case e: Throwable =>{
+        e.printStackTrace();
+      }
+    }
+  }
+
+  @throws[Exception]
+  def pushPublishChainEvent(publishChainEvent: scala.collection.mutable.Map[String, AnyRef],publishChainList : List[scala.collection.mutable.Map[String,AnyRef]], inputTopic: String)(implicit oec: OntologyEngineContext): Unit = {
+    val (actor, context, objData, eData) = generatePublishChainEventMetadata(publishChainEvent,publishChainList)
+    val beJobRequestEvent: String = logInstructionEvent(actor, context, objData, eData)
+    if (StringUtils.isBlank(beJobRequestEvent)) throw new ClientException("BE_JOB_REQUEST_EXCEPTION", "Event is not generated properly.")
+    try {
+      oec.kafkaClient.send(beJobRequestEvent, inputTopic)
+    }catch{
+      case e: Throwable =>{
+        println("Inside exception")
+        e.printStackTrace();
+      }
+    }
+  }
+
+  def generatePublishEventMetadata(publishChainEvent: scala.collection.mutable.Map[String, AnyRef], publishMetadata:PublishMetadata, actorId:String) : (Map[String, AnyRef], Map[String, AnyRef], Map[String, AnyRef], util.Map[String, AnyRef]) = {
+    val metadata: util.Map[String, AnyRef] = publishChainEvent
+    val eventString : String = JSONUtil.serialize(publishMetadata);
+    metadata.put("publishChainString",eventString)
+    val actor = Map("id" -> actorId, "type" -> "System".asInstanceOf[AnyRef])
+    val context = Map("channel" -> publishMetadata.context.getOrElse("channel",""), "pdata" -> Map("id" -> "org.sunbird.platform", "ver" -> "1.0").asJava, "env" -> publishMetadata.context.getOrElse("channel",""))
+    val objData = Map("id" -> publishChainEvent.getOrElse("identifier",""), "ver" -> publishMetadata.obj.getOrElse("ver",""))
+    val eData: util.Map[String, AnyRef] = new util.HashMap[String, AnyRef] {{
+      put("action", "publish")
+      put("publish_type",publishMetadata.publishType)
+      put("metadata", metadata)
+    }}
+    (actor, context, objData, eData)
+  }
+
+  def generatePublishChainEventMetadata(publishChainEvent: scala.collection.mutable.Map[String, AnyRef],publishChainList : List[scala.collection.mutable.Map[String,AnyRef]]): (Map[String, AnyRef], Map[String, AnyRef], Map[String, AnyRef], util.Map[String, AnyRef]) = {
+    val actor : Map[String,AnyRef] = publishChainEvent.getOrElse("actor",Map[String,AnyRef]()).asInstanceOf[Map[String, AnyRef]]
+    val context : Map[String,AnyRef] = publishChainEvent.getOrElse("context",Map[String,AnyRef]()).asInstanceOf[Map[String, AnyRef]]
+    val objData : Map[String,AnyRef] = publishChainEvent.getOrElse("object",Map[String,AnyRef]()).asInstanceOf[Map[String, AnyRef]]
+
+    val eData: util.Map[String, AnyRef] = new util.HashMap[String, AnyRef] {{
+      put("action", "publishchain")
+      put("publish_type", "public")
+      put("publishchain", publishChainList.asJava)
+    }}
+    (actor, context, objData, eData)
+  }
+
+
+  def logInstructionEvent(actor: util.Map[String, AnyRef], context: util.Map[String, AnyRef], `object`: util.Map[String, AnyRef], edata: util.Map[String, AnyRef]): String = {
+    val te = new PublishEvent
+    val unixTime = System.currentTimeMillis
+    val mid = "LP." + System.currentTimeMillis + "." + UUID.randomUUID
+    edata.put("iteration", iteration)
+    te.setEid(beJobRequesteventId)
+    te.setEts(unixTime)
+    te.setMid(mid)
+    te.setActor(actor)
+    te.setContext(context)
+    te.setObject(`object`)
+    te.setEdata(edata)
+    var jsonMessage:String= null
+    try {
+      mapper.registerModule(new DefaultScalaModule)
+      jsonMessage = mapper.writeValueAsString(te)
+    } catch {
+      case e: Exception =>
+        System.out.println(e.getMessage)
+    }
+    jsonMessage
+  }
+
+}

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/task/PublishCoreConfig.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/task/PublishCoreConfig.scala
@@ -1,0 +1,49 @@
+package org.sunbird.job.publish.task
+
+import com.typesafe.config.Config
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.TypeExtractor
+import org.apache.flink.streaming.api.scala.OutputTag
+import org.sunbird.job.publish.config.PublishConfig
+import org.sunbird.job.publish.core.PublishMetadata
+
+import java.util
+
+class PublishCoreConfig(override val config: Config) extends PublishConfig(config, "chain-publish"){
+
+	implicit val mapTypeInfo: TypeInformation[util.Map[String, AnyRef]] = TypeExtractor.getForClass(classOf[util.Map[String, AnyRef]])
+	implicit val stringTypeInfo: TypeInformation[String] = TypeExtractor.getForClass(classOf[String])
+	implicit val publishMetaTypeInfo: TypeInformation[PublishMetadata] = TypeExtractor.getForClass(classOf[PublishMetadata])
+
+	// Job Configuration
+	val jobEnv: String = config.getString("job.env")
+
+	// Kafka Topics Configuration
+	val kafkaInputTopic: String = config.getString("kafka.input.topic")
+	val postPublishTopic: String = config.getString("kafka.post_publish.topic")
+	val inputConsumerName = "publish-chain-consumer"
+	val questionSetTopic : String = config.getString("kafka.event.questionset.topic")
+	val contentTopic : String = config.getString("kafka.event.content.topic")
+
+	// Parallelism
+	override val kafkaConsumerParallelism: Int = config.getInt("task.consumer.parallelism")
+	val eventRouterParallelism: Int = config.getInt("task.router.parallelism")
+
+	// Metric List
+	val totalEventsCount = "total-events-count"
+	val skippedEventCount = "skipped-event-count"
+	val publishChainEventCount = "publishchain-count"
+	val publishChainSuccessEventCount = "publishchain-success-count"
+	val publishChainFailedEventCount = "publishchain-failed-count"
+
+	// Cassandra Configurations
+	val cassandraHost: String = config.getString("lms-cassandra.host")
+	val cassandraPort: Int = config.getInt("lms-cassandra.port")
+
+	// Out Tags
+	val publishChainOutTag: OutputTag[PublishMetadata] = OutputTag[PublishMetadata]("chain-publish")
+
+
+
+
+}

--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/task/PublishCoreStreamTask.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/task/PublishCoreStreamTask.scala
@@ -1,0 +1,55 @@
+package org.sunbird.job.publish.task
+
+import com.typesafe.config.ConfigFactory
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.TypeExtractor
+import org.apache.flink.api.java.utils.ParameterTool
+import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.sunbird.job.connector.FlinkKafkaConnector
+import org.sunbird.job.publish.core.{Event, PublishMetadata}
+import org.sunbird.job.publish.function.{PublishCoreFunction, PublishEventRouter}
+import org.sunbird.job.util.{FlinkUtil, HttpUtil}
+
+import java.io.File
+import java.util
+
+class PublishCoreStreamTask(config: PublishCoreConfig, kafkaConnector: FlinkKafkaConnector, httpUtil: HttpUtil) {
+
+	def process(): Unit = {
+	  implicit val env: StreamExecutionEnvironment = FlinkUtil.getExecutionContext(config)
+  	//implicit val env: StreamExecutionEnvironment = StreamExecutionEnvironment.createLocalEnvironment()
+		implicit val eventTypeInfo: TypeInformation[Event] = TypeExtractor.getForClass(classOf[Event])
+		implicit val mapTypeInfo: TypeInformation[util.Map[String, AnyRef]] = TypeExtractor.getForClass(classOf[util.Map[String, AnyRef]])
+		implicit val stringTypeInfo: TypeInformation[String] = TypeExtractor.getForClass(classOf[String])
+		implicit val publishMetaTypeInfo: TypeInformation[PublishMetadata] = TypeExtractor.getForClass(classOf[PublishMetadata])
+
+		val source = kafkaConnector.kafkaJobRequestSource[Event](config.kafkaInputTopic)
+		val processStreamTask = env.addSource(source).name(config.inputConsumerName)
+		  .uid(config.inputConsumerName).setParallelism(config.kafkaConsumerParallelism)
+		  .rebalance
+		  .process(new PublishEventRouter(config))
+		  .name("publish-event-router").uid("publish-event-router")
+		  .setParallelism(config.eventRouterParallelism)
+
+		processStreamTask.getSideOutput(config.publishChainOutTag).process(new PublishCoreFunction(config, httpUtil))
+		  .name("chain-publish-process").uid("chain-publish-process").setParallelism(1)
+		env.execute(config.jobName)
+
+	}
+}
+
+// $COVERAGE-OFF$ Disabling scoverage as the below code can only be invoked within flink cluster
+object PublishCoreStreamTask {
+
+	def main(args: Array[String]): Unit = {
+		val configFilePath = Option(ParameterTool.fromArgs(args).get("config.file.path"))
+		val config = configFilePath.map {
+			path => ConfigFactory.parseFile(new File(path)).resolve()
+		}.getOrElse(ConfigFactory.load("publish-core.conf").withFallback(ConfigFactory.systemEnvironment()))
+		val publishConfig = new PublishCoreConfig(config)
+		val kafkaUtil = new FlinkKafkaConnector(publishConfig)
+		val httpUtil = new HttpUtil
+		val task = new PublishCoreStreamTask(publishConfig, kafkaUtil, httpUtil)
+		task.process()
+	}
+}

--- a/publish-pipeline/publish-core/src/test/resources/test.conf
+++ b/publish-pipeline/publish-core/src/test/resources/test.conf
@@ -8,6 +8,8 @@ kafka {
   input.topic = "sunbirddev.learning.job.request"
   post_publish.topic = "sunbirddev.content.postpublish.request"
   groupId = "local-questionset-publish-group"
+  event.questionset.topic = "sunbirddev.assessment.publish.request"
+  event.content.topic = "sunbirddev.publish.job.request"
 }
 
 task {

--- a/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/fixture/EventFixture.scala
+++ b/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/fixture/EventFixture.scala
@@ -1,0 +1,12 @@
+package org.sunbird.job.fixture
+
+object EventFixture {
+
+  val PUBLISH_CHAIN_EVENT: String =
+  """
+    |{"eid": "BE_JOB_REQUEST","ets": 1634812181709,"mid": "LP.1634812181709.88b311c2-a733-4846-b2a2-31d9dceda436","actor": {"id": "interactivevideo-publish","type": "System"},
+    |"context": {"pdata": {"ver": "1.0","id": "org.sunbird.platform"},"channel": "0133866213417451520","env": "dev"},"object": {"ver": "1634810156009","id": "do_213392364484722688135"},"edata": {"publish_type": "public",
+    |"metadata": {},"publishchain": [{"identifier": "do identifier of questionset 1","mimeType": "application/vnd.sunbird.questionset","lastPublishedBy": "2ca3f787-379f-42d4-9cc3-6bc03a2d4cca","pkgVersion": null,"objectType": "QuestionSet","state": "Live","publishErr": "","order": 1},{"identifier": "do identifier of questionset 2","mimeType": "application/vnd.sunbird.questionset","lastPublishedBy": "2ca3f787-379f-42d4-9cc3-6bc03a2d4cca","pkgVersion": null,"objectType": "QuestionSet","state": "Live","publishErr": "","order": 2},],"action": "publishchain","iteration": 1,"contentType": "Resource"}}
+    |""".stripMargin
+
+}

--- a/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/spec/EventGeneratorSpec.scala
+++ b/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/spec/EventGeneratorSpec.scala
@@ -1,0 +1,44 @@
+package org.sunbird.job.publish.spec
+
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatestplus.mockito.MockitoSugar
+import org.sunbird.job.publish.core.PublishMetadata
+import org.sunbird.job.publish.helpers.EventGenerator
+import org.sunbird.job.util.OntologyEngineContext
+
+class EventGeneratorSpec extends FlatSpec with BeforeAndAfterAll with Matchers with MockitoSugar{
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+  }
+
+  "pushPublishEvent" should "push the generated event" in {
+    implicit val oec = new OntologyEngineContext()
+
+    val publishChainEvent : Map[String,AnyRef] = Map("identifier" -> "113430","mimeType" -> "application/vnd.sunbird.questionset",
+      "objectType" -> "QuestionSet", "lastPublishedBy"->"","pkgVersion"->"2","state"->"Processing")
+    val eData : Map[String,AnyRef]=  Map("publish_type"-> "public","action"->"publishchain","iteration"->"1")
+    val context : Map[String,AnyRef] = Map("channel"->"Sunbird","pdata"->Map("id"->"org.sunbird.platform","ver"->"3.0"),"env"->"dev")
+    val obj = Map("id"->"do_11342300698931200012","ver"->"1637732551528")
+    val publishChainList = List(Map[String, AnyRef]())
+    val publishMetadata = new PublishMetadata("",0,"",eData,context,obj,publishChainList);
+    EventGenerator.pushPublishEvent(publishChainEvent,publishMetadata,"kafka.input.questionset","questionset-publish")
+
+  }
+
+  "pushPublishChainEvent" should "push the generated chain event" in {
+    implicit val oec = new OntologyEngineContext()
+
+    val publishChainEvent : scala.collection.mutable.Map[String,AnyRef] =  scala.collection.mutable.Map("identifier" -> "113430","mimeType" -> "application/vnd.sunbird.questionset",
+      "objectType" -> "QuestionSet", "lastPublishedBy"->"","pkgVersion"->"2","state"->"Processing")
+    val publishChainList : List[scala.collection.mutable.Map[String,AnyRef]] = List(scala.collection.mutable.Map("identifier" -> "113430","mimeType" -> "application/vnd.sunbird.questionset",
+      "objectType" -> "QuestionSet", "lastPublishedBy"->"","pkgVersion"->"2","state"->"Processing"))
+    EventGenerator.pushPublishChainEvent(publishChainEvent,publishChainList,"kafka.input.questionset")
+
+  }
+
+}

--- a/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/spec/PublishCorePublishStreamTaskSpec.scala
+++ b/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/spec/PublishCorePublishStreamTaskSpec.scala
@@ -1,0 +1,94 @@
+package org.sunbird.job.spec
+
+import com.google.gson.Gson
+import com.typesafe.config.{Config, ConfigFactory}
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.typeutils.TypeExtractor
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
+import org.apache.flink.streaming.api.functions.source.SourceFunction
+import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
+import org.apache.flink.test.util.MiniClusterWithClientResource
+import org.cassandraunit.CQLDataLoader
+import org.cassandraunit.dataset.cql.FileCQLDataSet
+import org.cassandraunit.utils.EmbeddedCassandraServerHelper
+import org.mockito.Mockito
+import org.mockito.Mockito.when
+import org.sunbird.job.connector.FlinkKafkaConnector
+import org.sunbird.job.fixture.EventFixture
+import org.sunbird.job.publish.config.PublishConfig
+import org.sunbird.job.publish.core.Event
+import org.sunbird.job.publish.task.{PublishCoreConfig, PublishCoreStreamTask}
+import org.sunbird.job.util.{CassandraUtil, CloudStorageUtil, HttpUtil, Neo4JUtil}
+import org.sunbird.spec.{BaseMetricsReporter, BaseTestSpec}
+
+import java.util
+
+class PublishCoreStreamTaskSpec extends BaseTestSpec {
+
+	implicit val mapTypeInfo: TypeInformation[java.util.Map[String, AnyRef]] = TypeExtractor.getForClass(classOf[java.util.Map[String, AnyRef]])
+	implicit val strTypeInfo: TypeInformation[String] = TypeExtractor.getForClass(classOf[String])
+
+	val flinkCluster = new MiniClusterWithClientResource(new MiniClusterResourceConfiguration.Builder()
+	  .setConfiguration(testConfiguration())
+	  .setNumberSlotsPerTaskManager(1)
+	  .setNumberTaskManagers(1)
+	  .build)
+	val mockKafkaUtil: FlinkKafkaConnector = mock[FlinkKafkaConnector](Mockito.withSettings().serializable())
+	val config: Config = ConfigFactory.load("test.conf").withFallback(ConfigFactory.systemEnvironment())
+	implicit val jobConfig: PublishCoreConfig = new PublishCoreConfig(config)
+
+	val mockHttpUtil = mock[HttpUtil](Mockito.withSettings().serializable())
+	val mockNeo4JUtil: Neo4JUtil = mock[Neo4JUtil](Mockito.withSettings().serializable())
+	var cassandraUtil: CassandraUtil = _
+	val publishConfig: PublishConfig = new PublishConfig(config, "")
+	val cloudStorageUtil: CloudStorageUtil = new CloudStorageUtil(publishConfig)
+
+	override protected def beforeAll(): Unit = {
+		super.beforeAll()
+		EmbeddedCassandraServerHelper.startEmbeddedCassandra(80000L)
+		cassandraUtil = new CassandraUtil(jobConfig.cassandraHost, jobConfig.cassandraPort)
+		val session = cassandraUtil.session
+		val dataLoader = new CQLDataLoader(session)
+		dataLoader.load(new FileCQLDataSet(getClass.getResource("/test.cql").getPath, true, true))
+		flinkCluster.before()
+	}
+
+	override protected def afterAll(): Unit = {
+		super.afterAll()
+		try {
+			EmbeddedCassandraServerHelper.cleanEmbeddedCassandra()
+		} catch {
+			case ex: Exception => {
+			}
+		}
+		flinkCluster.after()
+	}
+
+	//TODO: provide test cases.
+	def initialize(): Unit = {
+		when(mockKafkaUtil.kafkaJobRequestSource[Event](jobConfig.kafkaInputTopic)).thenReturn(new PublishCoreEventSource)
+	}
+
+	ignore should " publish the publish chain event " in {
+		initialize
+		new PublishCoreStreamTask(jobConfig, mockKafkaUtil, mockHttpUtil).process()
+		BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.totalEventsCount}").getValue() should be(1)
+		BaseMetricsReporter.gaugeMetrics(s"${jobConfig.jobName}.${jobConfig.publishChainEventCount}").getValue() should be(1)
+	}
+}
+
+private class PublishCoreEventSource extends SourceFunction[Event] {
+
+	override def run(ctx: SourceContext[Event]) {
+		ctx.collect(jsonToEvent(EventFixture.PUBLISH_CHAIN_EVENT))
+	}
+
+	override def cancel() = {}
+
+	def jsonToEvent(json: String): Event = {
+		val gson = new Gson()
+		val data = gson.fromJson(json, new util.LinkedHashMap[String, Any]().getClass).asInstanceOf[util.Map[String, Any]]
+		new Event(data, 0, 10)
+	}
+
+}

--- a/publish-pipeline/questionset-publish/src/main/resources/questionset-publish.conf
+++ b/publish-pipeline/questionset-publish/src/main/resources/questionset-publish.conf
@@ -8,6 +8,7 @@ kafka {
   input.topic = "sunbirddev.assessment.publish.request"
   post_publish.topic = "sunbirddev.content.postpublish.request"
   groupId = "local-questionset-publish-group"
+  publishchain.topic = "sunbirddev.publishchain.publish.request"
 }
 
 task {

--- a/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/function/PublishEventRouter.scala
+++ b/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/function/PublishEventRouter.scala
@@ -35,11 +35,11 @@ class PublishEventRouter(config: QuestionSetPublishConfig) extends BaseProcessFu
 			event.objectType match {
 				case "Question" | "QuestionImage" => {
 					logger.info("PublishEventRouter :: Sending Question For Publish Having Identifier: " + event.objectId)
-					context.output(config.questionPublishOutTag, PublishMetadata(event.objectId, event.objectType, event.mimeType, event.pkgVersion, event.publishType))
+					context.output(config.questionPublishOutTag, PublishMetadata(event.objectId, event.objectType, event.mimeType, event.pkgVersion, event.publishType,event.publishChainString))
 				}
 				case "QuestionSet" | "QuestionSetImage" => {
 					logger.info("PublishEventRouter :: Sending QuestionSet For Publish Having Identifier: " + event.objectId)
-					context.output(config.questionSetPublishOutTag, PublishMetadata(event.objectId, event.objectType, event.mimeType, event.pkgVersion, event.publishType))
+					context.output(config.questionSetPublishOutTag, PublishMetadata(event.objectId, event.objectType, event.mimeType, event.pkgVersion, event.publishType,event.publishChainString))
 				}
 				case _ => {
 					metrics.incCounter(config.skippedEventCount)

--- a/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/function/QuestionSetPublishFunction.scala
+++ b/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/function/QuestionSetPublishFunction.scala
@@ -89,8 +89,8 @@ class QuestionSetPublishFunction(config: QuestionSetPublishConfig, httpUtil: Htt
         // Generate ECAR
         val objWithEcar = generateECAR(enrichedObj, pkgTypes)(ec, cloudStorageUtil, config, definitionCache, definitionConfig, httpUtil)
         // Generate PDF URL
-    //    val updatedObj = generatePreviewUrl(objWithEcar, qList)(httpUtil, cloudStorageUtil)
-     //   saveOnSuccess(updatedObj)(neo4JUtil, cassandraUtil, readerConfig, definitionCache, definitionConfig)
+        val updatedObj = generatePreviewUrl(objWithEcar, qList)(httpUtil, cloudStorageUtil)
+        saveOnSuccess(updatedObj)(neo4JUtil, cassandraUtil, readerConfig, definitionCache, definitionConfig)
         logger.info("QuestionSet publishing completed successfully for : " + data.identifier)
         publishNextEvent(data,objWithEcar.metadata.getOrElse("downloadUrl","").toString)
         metrics.incCounter(config.questionSetPublishSuccessEventCount)

--- a/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/function/QuestionSetPublishFunction.scala
+++ b/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/function/QuestionSetPublishFunction.scala
@@ -10,7 +10,7 @@ import org.slf4j.LoggerFactory
 import org.sunbird.job.domain.`object`.{DefinitionCache, ObjectDefinition}
 import org.sunbird.job.publish.config.PublishConfig
 import org.sunbird.job.publish.core.{DefinitionConfig, ExtDataConfig, ObjectData}
-import org.sunbird.job.publish.helpers.EcarPackageType
+import org.sunbird.job.publish.helpers.{EcarPackageType, EventGenerator}
 import org.sunbird.job.questionset.publish.domain.PublishMetadata
 import org.sunbird.job.questionset.publish.helpers.QuestionSetPublisher
 import org.sunbird.job.questionset.publish.util.QuestionPublishUtil
@@ -20,6 +20,7 @@ import org.sunbird.job.{BaseProcessFunction, Metrics}
 
 import java.lang.reflect.Type
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext
 
@@ -88,9 +89,10 @@ class QuestionSetPublishFunction(config: QuestionSetPublishConfig, httpUtil: Htt
         // Generate ECAR
         val objWithEcar = generateECAR(enrichedObj, pkgTypes)(ec, cloudStorageUtil, config, definitionCache, definitionConfig, httpUtil)
         // Generate PDF URL
-        val updatedObj = generatePreviewUrl(objWithEcar, qList)(httpUtil, cloudStorageUtil)
-        saveOnSuccess(updatedObj)(neo4JUtil, cassandraUtil, readerConfig, definitionCache, definitionConfig)
+    //    val updatedObj = generatePreviewUrl(objWithEcar, qList)(httpUtil, cloudStorageUtil)
+     //   saveOnSuccess(updatedObj)(neo4JUtil, cassandraUtil, readerConfig, definitionCache, definitionConfig)
         logger.info("QuestionSet publishing completed successfully for : " + data.identifier)
+        publishNextEvent(data,objWithEcar.metadata.getOrElse("downloadUrl","").toString)
         metrics.incCounter(config.questionSetPublishSuccessEventCount)
       } else {
         saveOnFailure(obj, pubMsgs, data.pkgVersion)(neo4JUtil)
@@ -137,5 +139,31 @@ class QuestionSetPublishFunction(config: QuestionSetPublishConfig, httpUtil: Htt
   def isValidChildQuestion(obj: ObjectData): Boolean = {
     StringUtils.equalsIgnoreCase("Parent", obj.getString("visibility", ""))
   }
+
+  private def publishNextEvent(data: PublishMetadata,downloadUrl:String) = {
+    if (StringUtils.isNotEmpty(data.publishChainString)) {
+      implicit val oec = new OntologyEngineContext()
+      val publishChainEvent: Map[String, AnyRef] = JSONUtil.deserialize[Map[String, AnyRef]](data.publishChainString)
+      val eData: Map[String, AnyRef] = publishChainEvent.getOrElse("eData", Map[String, AnyRef]()).asInstanceOf[Map[String, AnyRef]]
+      val publishChain: List[Map[String, AnyRef]] = eData.getOrElse("publishchain", List[Map[String, AnyRef]]()).asInstanceOf[List[Map[String, AnyRef]]]
+      val updatedList = ListBuffer[mutable.Map[String, AnyRef]]()
+      for (publishObject: Map[String, AnyRef] <- publishChain) {
+        val publishObj: mutable.Map[String, AnyRef] = collection.mutable.Map(publishObject.toSeq: _*)
+        if (StringUtils.equals(publishObject.getOrElse("identifier", "").toString, data.identifier)) {
+          publishObj.put("state", "Live")
+          publishObj.put("downloadUrl",downloadUrl)
+        }
+        updatedList += publishObj;
+
+      }
+
+      val updatedEData: mutable.Map[String, AnyRef] = collection.mutable.Map(eData.toSeq: _*)
+      val updatedPublishChainEvent: mutable.Map[String, AnyRef] = collection.mutable.Map(publishChainEvent.toSeq: _*)
+      updatedEData.put("publishchain", updatedList.toList)
+      updatedPublishChainEvent.put("edata", updatedEData)
+      EventGenerator.pushPublishChainEvent(updatedPublishChainEvent,updatedList.toList, config.publishChainTopic)
+    }
+  }
+
 
 }

--- a/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/publish/domain/Event.scala
+++ b/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/publish/domain/Event.scala
@@ -24,7 +24,10 @@ class Event(eventMap: java.util.Map[String, Any], partition: Int, offset: Long) 
 	def objectId: String = readOrDefault[String]("edata.metadata.identifier", "")
 
 	def objectType: String = readOrDefault[String]("edata.metadata.objectType", "")
-  
+
+	def publishChainString : String = readOrDefault[String]("edata.metadata.publishChainString", "");
+
+
 	def pkgVersion: Double = {
     val pkgVersion = readOrDefault[Int]("edata.metadata.pkgVersion", 0)
     pkgVersion.toDouble

--- a/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/publish/domain/Models.scala
+++ b/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/publish/domain/Models.scala
@@ -1,3 +1,3 @@
 package org.sunbird.job.questionset.publish.domain
 
-case class PublishMetadata(identifier: String, objectType: String, mimeType: String, pkgVersion: Double, publishType: String)
+case class PublishMetadata(identifier: String, objectType: String, mimeType: String, pkgVersion: Double, publishType: String,publishChainString: String)

--- a/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/task/QuestionSetPublishConfig.scala
+++ b/publish-pipeline/questionset-publish/src/main/scala/org/sunbird/job/questionset/task/QuestionSetPublishConfig.scala
@@ -23,6 +23,7 @@ class QuestionSetPublishConfig(override val config: Config) extends PublishConfi
 	val kafkaInputTopic: String = config.getString("kafka.input.topic")
 	val postPublishTopic: String = config.getString("kafka.post_publish.topic")
 	val inputConsumerName = "questionset-publish-consumer"
+	val publishChainTopic : String = config.getString("kafka.publishchain.topic")
 
 	// Parallelism
 	override val kafkaConsumerParallelism: Int = config.getInt("task.consumer.parallelism")


### PR DESCRIPTION
New Feature - Publish Pipeline changes for generating ecar for interactive video.

Changes in following modules
1) Publish-pipeline/ publish-core 

- Reads publish chain event on new topic and generates respective question-set or content publish event depending on object type and state 
- Changes in ecar to unzip and copy contents from question set ecar if the event is a publish-chain event

2)Publish-pipeline/ questionset-publish  
- Changes to publish next event has publishchain string

3) Publish-pipeline/ content-publish  
- changes to read publish chain object while genrating ecar

4) jobs-core - common functionalities and classes required for posting events
 

