### PR TITLE
Issue #SB-28452 fix: Collection keywords restore

### DIFF
--- a/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/publish/helpers/CollectionPublisher.scala
+++ b/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/publish/helpers/CollectionPublisher.scala
@@ -224,7 +224,14 @@ trait CollectionPublisher extends ObjectReader with SyncMessagesGenerator with O
           }
         } else keywords
         updatedKeywords.filter(record => record.trim.nonEmpty).distinct
-      } else obj.metadata.getOrElse("keywords", Array.empty).asInstanceOf[util.Collection[String]].asScala.toArray[String]
+      } else {
+        obj.metadata("keywords") match {
+          case _: Array[String] => obj.metadata.getOrElse("keywords", Array.empty).asInstanceOf[Array[String]]
+          case kwValue: String => Array[String](kwValue)
+          case _: util.Collection[String] => obj.metadata.getOrElse("keywords", Array.empty).asInstanceOf[util.Collection[String]].asScala.toArray[String]
+          case _ => Array.empty[String]
+        }
+      }
       new ObjectData(obj.identifier, obj.metadata ++ updatedMetadataMap + ("keywords" -> finalKeywords), obj.extData, obj.hierarchy)
     } else obj
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-28452" title="SB-28452" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />SB-28452</a>  Under a particular condition, the 'keywords' metadata becomes empty, after publishing any collection.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran Unit Tests

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules