### PR TITLE
Sb 29579: Disabled throwing exception on delete old registry

### DIFF
--- a/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/functions/CertificateGeneratorFunction.scala
+++ b/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/functions/CertificateGeneratorFunction.scala
@@ -131,12 +131,11 @@ class CertificateGeneratorFunction(config: CertificateGeneratorConfig, httpUtil:
           callCertificateRc(config.rcDeleteApi, event.oldId, null)
         } catch {
           case ex: ServerException =>
-            logger.error("Rc deletion failed | old id is not present :: identifier" + event.oldId + " :: " + ex.getMessage)
+            logger.error("Rc deletion failed | old id is not present :: identifier " + event.oldId + " :: " + ex.getMessage)
             //when record not present for oldId in rc registry, calls old registry deletion
             deleteOldRegistry(event.oldId)
           case e: UnirestException =>
-            logger.error("Rc deletion failed due to connection :: identifier" + event.oldId + " :: " + e.getMessage)
-            //throw ServerException("ERR_CONNECTION_ERROR", "Rc deletion failed | error msg: " + e.getMessage)
+            logger.error("Rc deletion failed due to connection :: identifier " + event.oldId + " :: " + e.getMessage)
         }
       }
       val related = event.related
@@ -157,8 +156,7 @@ class CertificateGeneratorFunction(config: CertificateGeneratorConfig, httpUtil:
       deleteEsRecord(id)
     } catch {
       case ex: Exception =>
-        logger.error("Old registry deletion failed | old id is not present :: identifier" + id+ " :: " + ex.getMessage)
-        //throw ServerException("ERR_DELETION_OLD_REG", "Old registry deletion failed | error msg: " + ex.getMessage)
+        logger.error("Old registry deletion failed | old id is not present :: identifier " + id+ " :: " + ex.getMessage)
 
     }
   }

--- a/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/functions/CertificateGeneratorFunction.scala
+++ b/credential-generator/collection-certificate-generator/src/main/scala/org/sunbird/job/certgen/functions/CertificateGeneratorFunction.scala
@@ -136,7 +136,7 @@ class CertificateGeneratorFunction(config: CertificateGeneratorConfig, httpUtil:
             deleteOldRegistry(event.oldId)
           case e: UnirestException =>
             logger.error("Rc deletion failed due to connection :: identifier" + event.oldId + " :: " + e.getMessage)
-            throw ServerException("ERR_CONNECTION_ERROR", "Rc deletion failed | error msg: " + e.getMessage)
+            //throw ServerException("ERR_CONNECTION_ERROR", "Rc deletion failed | error msg: " + e.getMessage)
         }
       }
       val related = event.related
@@ -158,7 +158,7 @@ class CertificateGeneratorFunction(config: CertificateGeneratorConfig, httpUtil:
     } catch {
       case ex: Exception =>
         logger.error("Old registry deletion failed | old id is not present :: identifier" + id+ " :: " + ex.getMessage)
-        throw ServerException("ERR_DELETION_OLD_REG", "Old registry deletion failed | error msg: " + ex.getMessage)
+        //throw ServerException("ERR_DELETION_OLD_REG", "Old registry deletion failed | error msg: " + ex.getMessage)
 
     }
   }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-29579" title="SB-29579" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />SB-29579</a>  Portal : Re-issuing the certificate is not displaying the notification for the user and the user is unable to verify the re-issued certificate 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules