### PR TITLE
Issue #SB-29540 merge: Merge pull request #526 from Jayaprakash8887/r…

### DIFF
--- a/asset-enrichment/src/main/scala/org/sunbird/job/assetenricment/helpers/ImageEnrichmentHelper.scala
+++ b/asset-enrichment/src/main/scala/org/sunbird/job/assetenricment/helpers/ImageEnrichmentHelper.scala
@@ -78,7 +78,7 @@ trait ImageEnrichmentHelper {
 
   def isImageOptimizable(file: File, dimensionX: Int, dimensionY: Int): Boolean = {
     val inputFileName = file.getAbsolutePath
-    val imageInfo = new Info(inputFileName, false)
+    val imageInfo = new Info(inputFileName, true)
     val width = imageInfo.getImageWidth
     val height = imageInfo.getImageHeight
     (dimensionX < width && dimensionY < height)


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-29540" title="SB-29540" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />SB-29540</a>  asset-enrichment job is failing with NumberFormatException
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
…elease-4.8.0

Issue #SB-29540 fix: Number format exception

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules