### PR TITLE
Issue #SB-30016 fix: External file download failing

### DIFF
--- a/jobs-core/src/main/scala/org/sunbird/job/util/HttpUtil.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/HttpUtil.scala
@@ -64,11 +64,9 @@ class HttpUtil extends Serializable {
     if (!saveFile.exists) saveFile.mkdirs
     val urlObject = new URL(url)
     val filePath = downloadLocation + "/" + Slug.makeSlug(urlObject.getPath.substring(urlObject.getPath.lastIndexOf("/")+1))
-    if(filePath.equalsIgnoreCase(downloadLocation + "/")) null else {
-      urlObject #> new File(filePath) !!
-      val downloadedFile = new File(filePath)
-      downloadedFile
-    }
+    urlObject #> new File(filePath) !!
+    val downloadedFile = new File(filePath)
+    downloadedFile
   }
 
   private def validateRequest(url: String, headerParam: Map[String, String]): Unit = {

--- a/jobs-core/src/main/scala/org/sunbird/job/util/HttpUtil.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/HttpUtil.scala
@@ -63,7 +63,7 @@ class HttpUtil extends Serializable {
     val saveFile = new File(downloadLocation)
     if (!saveFile.exists) saveFile.mkdirs
     val urlObject = new URL(url)
-    val filePath = downloadLocation + "/" + urlObject.getPath.substring(urlObject.getPath.lastIndexOf("/")+1)
+    val filePath = downloadLocation + "/" + Slug.makeSlug(urlObject.getPath.substring(urlObject.getPath.lastIndexOf("/")+1))
     if(filePath.equalsIgnoreCase(downloadLocation + "/")) null else {
       urlObject #> new File(filePath) !!
       val downloadedFile = new File(filePath)

--- a/jobs-core/src/test/scala/org/sunbird/spec/HTTPUtilSpec.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/HTTPUtilSpec.scala
@@ -50,8 +50,9 @@ class HTTPUtilSpec extends FlatSpec with Matchers {
     val fileUrl = "https://dockstaging.sunbirded.org/"
     val httpUtil = new HttpUtil
     val downloadPath = "/tmp/content" + File.separator + "_temp_" + System.currentTimeMillis
-    val downloadedFile = httpUtil.downloadFile(fileUrl, downloadPath)
+    assertThrows[IllegalArgumentException] {
+      httpUtil.downloadFile(fileUrl, downloadPath)
+    }
 
-    assert(downloadedFile == null)
   }
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-30016" title="SB-30016" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />SB-30016</a>  VDN Bulk upload Fails  when the CSV contains a PUBLIC URL(eg. DROPBOX, ie. any non-google drive)  which has  UPPER CASE Filenames/spaces
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran Unit Tests

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules