### PR TITLE
Upgrade kafka-clients dependency for Kafka 4.x compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<scala.version>2.12</scala.version>
 		<scala.maj.version>2.12.11</scala.maj.version>
 		<flink.version>1.13.6</flink.version>
-		<kafka.version>2.4.1</kafka.version>
+		<kafka.version>3.7.1</kafka.version>
 		<jackson-jaxrs.version>1.9.13</jackson-jaxrs.version>
 		<scoverage.plugin.version>1.4.0</scoverage.plugin.version>
 	</properties>


### PR DESCRIPTION
## Summary

This PR upgrades the kafka-clients dependency to a version compatible with Kafka 4.x.