### PR TITLE
fix: Address Dependabot CVEs, remove dead ZooKeeper config, suppress JanusGraph WARN logs

### DIFF
--- a/asset-enrichment/pom.xml
+++ b/asset-enrichment/pom.xml
@@ -158,6 +158,18 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-cql</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/hadoop/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-core</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/graphdb/management/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
 
                             <transformers>

--- a/cassandra-data-migration/pom.xml
+++ b/cassandra-data-migration/pom.xml
@@ -126,6 +126,18 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-cql</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/hadoop/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-core</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/graphdb/management/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>

--- a/dialcode-context-updater/pom.xml
+++ b/dialcode-context-updater/pom.xml
@@ -126,6 +126,18 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-cql</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/hadoop/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-core</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/graphdb/management/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>

--- a/jobs-core/pom.xml
+++ b/jobs-core/pom.xml
@@ -180,29 +180,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <version>3.8.4</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-reload4j</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>3.4.2</version>

--- a/jobs-core/pom.xml
+++ b/jobs-core/pom.xml
@@ -52,12 +52,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.15.4</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-scala_${scala.version}</artifactId>
-            <version>2.15.4</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>redis.clients</groupId>

--- a/jobs-core/src/main/resources/base-config.conf
+++ b/jobs-core/src/main/resources/base-config.conf
@@ -1,6 +1,5 @@
 kafka {
   broker-servers = "localhost:9092"
-  zookeeper = "localhost:2181"
 }
 
 job {

--- a/jobs-core/src/main/scala/org/sunbird/job/BaseJobConfig.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/BaseJobConfig.scala
@@ -14,7 +14,6 @@ class BaseJobConfig(val config: Config, val jobName: String) extends Serializabl
   implicit val metricTypeInfo: TypeInformation[String] = TypeExtractor.getForClass(classOf[String])
 
   val kafkaBrokerServers: String = config.getString("kafka.broker-servers")
-  val zookeeper: String = config.getString("kafka.zookeeper")
   val groupId: String = config.getString("kafka.groupId")
   val restartAttempts: Int = config.getInt("task.restart-strategy.attempts")
   val delayBetweenAttempts: Long = config.getLong("task.restart-strategy.delay")

--- a/jobs-core/src/test/resources/base-test.conf
+++ b/jobs-core/src/test/resources/base-test.conf
@@ -1,6 +1,5 @@
 kafka {
   broker-servers = "localhost:9093"
-  zookeeper = "localhost:2183"
   map.input.topic = "local.telemetry.map.input"
   map.output.topic = "local.telemetry.map.output"
   string.input.topic = "local.telemetry.string.input"

--- a/jobs-core/src/test/scala/org/sunbird/fixture/EventFixture.scala
+++ b/jobs-core/src/test/scala/org/sunbird/fixture/EventFixture.scala
@@ -33,7 +33,6 @@ object EventFixture {
       |  string.input.topic = "local.telemetry.string.input"
       |  string.output.topic = "local.telemetry.string.output"
       |  broker-servers = "localhost:9093"
-      |  zookeeper = "localhost:2183"
       |  groupId = "pipeline-preprocessor-group"
       |  auto.offset.reset = "earliest"
       |  producer {

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 		<scoverage.plugin.version>1.4.0</scoverage.plugin.version>
 		<netty.version>4.1.129.Final</netty.version>
 		<jetty.version>9.4.57.v20241219</jetty.version>
-		<jackson.version>2.15.4</jackson.version>
+		<jackson.version>2.18.6</jackson.version>
 	</properties>
 
 	<repositories>
@@ -161,6 +161,11 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>
+				<version>${jackson.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>com.fasterxml.jackson.core</groupId>
+				<artifactId>jackson-databind</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,29 @@
 				<version>1.10.3</version>
 			</dependency>
 			<dependency>
+				<groupId>org.apache.zookeeper</groupId>
+				<artifactId>zookeeper</artifactId>
+				<version>3.8.6</version>
+				<exclusions>
+					<exclusion>
+						<groupId>io.netty</groupId>
+						<artifactId>*</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-log4j12</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-reload4j</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>log4j</groupId>
+						<artifactId>log4j</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-server</artifactId>
 				<version>${jetty.version}</version>

--- a/publish-pipeline/knowlg-publish/pom.xml
+++ b/publish-pipeline/knowlg-publish/pom.xml
@@ -124,6 +124,18 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-cql</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/hadoop/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-core</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/graphdb/management/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>

--- a/publish-pipeline/live-node-publisher/pom.xml
+++ b/publish-pipeline/live-node-publisher/pom.xml
@@ -119,6 +119,18 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-cql</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/hadoop/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-core</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/graphdb/management/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>

--- a/qrcode-image-generator/pom.xml
+++ b/qrcode-image-generator/pom.xml
@@ -136,6 +136,18 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-cql</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/hadoop/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-core</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/graphdb/management/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>

--- a/transaction-event-processor/pom.xml
+++ b/transaction-event-processor/pom.xml
@@ -166,6 +166,18 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-cql</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/hadoop/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-core</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/graphdb/management/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                             <transformers>
                                 <transformer

--- a/video-stream-generator/pom.xml
+++ b/video-stream-generator/pom.xml
@@ -169,6 +169,18 @@
                                         <exclude>META-INF/*.RSA</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-cql</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/hadoop/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.janusgraph:janusgraph-core</artifact>
+                                    <excludes>
+                                        <exclude>org/janusgraph/graphdb/management/**</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                             <transformers>
                                 <transformer

--- a/video-stream-generator/pom.xml
+++ b/video-stream-generator/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-scala_${scala.version}</artifactId>
-            <version>2.15.4</version>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.sunbird</groupId>


### PR DESCRIPTION
## Summary

This PR addresses several Dependabot security advisories, cleans up dead ZooKeeper Kafka configuration left over from the pre-Kafka-3.x era, and eliminates spurious JanusGraph `reflections8` WARN logs at runtime — all without touching `logback` config.

---

## Security Fixes

| CVE | Package | Before | After |
|-----|---------|--------|-------|
| Number Length Constraint Bypass DoS | `jackson-core` | 2.15.4 | 2.18.6 |
| Hostname verification bypass | `zookeeper` | 3.8.4 | 3.8.6 |
| Improper config value handling | `zookeeper` | 3.8.4 | 3.8.6 |

**jackson-databind** also added to root `dependencyManagement` so Flink's older transitive jackson (~2.12.x) cannot win in modules like `jobs-distribution` that pull Flink without `provided` scope.

**Not fixed (upstream has no patch yet):**
- `jetty-http` #13 (fix requires Jetty 12 → needs Java 17 + Jakarta EE namespace, blocked by Flink 1.13.6)

---

## ZooKeeper Cleanup

Kafka 3.x clients use `bootstrap.servers` exclusively — ZooKeeper is never referenced by the Kafka client API. Removed all dead references:

- `val zookeeper` field removed from `BaseJobConfig`
- `kafka.zookeeper` removed from `base-config.conf`, `base-test.conf`, and `EventFixture` inline config
- Direct `zookeeper` dependency removed from `jobs-core/pom.xml`; moved to root `dependencyManagement` for version-pinning only (ZooKeeper still arrives transitively via `hadoop-common`)

---

## JanusGraph reflections8 WARN Suppression

On the first graph traversal, `JanusGraphTraverserUtil`'s static initializer uses `reflections8` to scan all `org.janusgraph` packages. It finds:

- CQL-Hadoop OLAP bridge classes in `janusgraph-cql` (`CQLHadoopScanRunner`, `CqlBinaryInputFormat`, `CqlHadoopStoreManager`) — whose bytecode references abstract types from the absent `janusgraph-hadoop` optional module
- `JanusGraphManager` in `janusgraph-core` — which implements `GraphManager` from the absent `gremlin-server` optional module

`reflections8` logs a `WARN` for each missing supertype. These are harmless (publish succeeds), but noisy.

**Fix:** Added shade plugin filters in all 8 job modules to strip these unused optional-module bridge classes from the fat jar at build time:

```xml
<filter>
    <artifact>org.janusgraph:janusgraph-cql</artifact>
    <excludes>
        <exclude>org/janusgraph/hadoop/**</exclude>
    </excludes>
</filter>
<filter>
    <artifact>org.janusgraph:janusgraph-core</artifact>
    <excludes>
        <exclude>org/janusgraph/graphdb/management/**</exclude>
    </excludes>
</filter>
```

Both exclusions are safe: our code calls `JanusGraphFactory.open(Configuration)` which routes through `open(ReadConfiguration)` → `open(ReadConfiguration, String)`. The management package is only reached via the Gremlin Server shortcut notation (`open(String graphName)`) which we do not use.

---

## Test Plan

- [ ] Build all modules: `mvn clean install -DskipTests -DCLOUD_STORE_GROUP_ID=org.sunbird -DCLOUD_STORE_ARTIFACT_ID=cloud-store-sdk_2.12 -DCLOUD_STORE_VERSION=1.5.0`
- [ ] Deploy `knowlg-publish` job and trigger a publish event — verify no `reflections8` WARN logs appear
- [ ] Confirm publish completes successfully end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)