### PR TITLE
fix(jobs-core): guard redis.host reads with hasPath to prevent startup crash when Redis is absent

### DIFF
--- a/jobs-core/src/main/scala/org/sunbird/job/cache/RedisConnect.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/cache/RedisConnect.scala
@@ -10,8 +10,8 @@ class RedisConnect(jobConfig: BaseJobConfig, host: Option[String] = None, port: 
   private val serialVersionUID = -396824011996012513L
 
   val config: Config = jobConfig.config
-  val redisHost: String = host.getOrElse(Option(config.getString("redis.host")).getOrElse("localhost"))
-  val redisPort: Int = port.getOrElse(Option(config.getInt("redis.port")).getOrElse(6379))
+  val redisHost: String = host.getOrElse(if (config.hasPath("redis.host")) config.getString("redis.host") else "localhost")
+  val redisPort: Int = port.getOrElse(if (config.hasPath("redis.port")) config.getInt("redis.port") else 6379)
   private val logger = LoggerFactory.getLogger(classOf[RedisConnect])
 
   if (jobConfig.redisEnabled) {

--- a/jobs-core/src/test/scala/org/sunbird/spec/CoreTestSpec.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/CoreTestSpec.scala
@@ -123,6 +123,19 @@ class CoreTestSpec extends BaseSpec with Matchers with MockitoSugar {
     dataCache.close()
   }
 
+  "RedisConnect" should "not throw when redis.enabled = false and redis.host/port are absent" in {
+    val minimalConfig: Config = ConfigFactory.parseString(
+      """kafka { broker-servers = "localhost:9092", zookeeper = "localhost:2181", groupId = "test" }
+        |task { restart-strategy.attempts = 3, restart-strategy.delay = 10000, parallelism = 1,
+        |  consumer.parallelism = 1, checkpointing.compressed = false, checkpointing.interval = 60000,
+        |  checkpointing.pause.between.seconds = 30000 }
+        |lms-cassandra { host = "localhost", port = 9042 }
+        |redis.enabled = false
+        |""".stripMargin)
+    val minimalBaseConfig: BaseJobConfig = new BaseJobConfig(minimalConfig, "base-job")
+    noException should be thrownBy new RedisConnect(minimalBaseConfig)
+  }
+
   "FilnkUtil" should "get the flink util context" in {
     val config = ConfigFactory.empty()
     config.entrySet()

--- a/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/task/KnowlgPublishConfig.scala
+++ b/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/task/KnowlgPublishConfig.scala
@@ -61,7 +61,7 @@ class KnowlgPublishConfig(override val config: Config) extends PublishConfig(con
 
 
   // Redis Configurations
-  val nodeStore: Int = config.getInt("redis.database.contentCache.id")
+  val nodeStore: Int = if (redisEnabled) config.getInt("redis.database.contentCache.id") else 0
 
   // Question/QuestionSet Configurations (merged from questionset-publish)
   val questionKeyspaceName: String = if (config.hasPath("question.keyspace")) config.getString("question.keyspace") else contentKeyspaceName

--- a/publish-pipeline/live-node-publisher/src/main/scala/org/sunbird/job/livenodepublisher/task/LiveNodePublisherConfig.scala
+++ b/publish-pipeline/live-node-publisher/src/main/scala/org/sunbird/job/livenodepublisher/task/LiveNodePublisherConfig.scala
@@ -56,7 +56,7 @@ class LiveNodePublisherConfig(override val config: Config) extends PublishConfig
 
 
   // Redis Configurations
-  val nodeStore: Int = config.getInt("redis.database.contentCache.id")
+  val nodeStore: Int = if (redisEnabled) config.getInt("redis.database.contentCache.id") else 0
 
   // Out Tags
   val contentPublishOutTag: OutputTag[Event] = OutputTag[Event]("live-content-publish")


### PR DESCRIPTION
## Summary

- Replace broken `Option(config.getString("redis.host"))` pattern in `RedisConnect` with `hasPath` guards — Typesafe Config throws `ConfigException$Missing` before `Option` can wrap it, so the `"localhost"` fallback never fired
- Guard `redis.database.contentCache.id` reads in `KnowlgPublishConfig` and `LiveNodePublisherConfig` behind `if (redisEnabled)` with a safe default of `0`

## Why

Jobs were crashing at startup with `ConfigException$Missing: redis.host` even with `redis.enabled = false` set in the ConfigMap, because `RedisConnect` read host/port unconditionally at construction time before any enabled check could run.
