### PR TITLE
feat: Migrate to cloud-storage-sdk v2.0.1 with CSP Maven profiles

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
       - run:
           name: Execute coverage report
           command: |
-            mvn clean scoverage:report  -DCLOUD_STORE_GROUP_ID=$CLOUD_STORE_GROUP_ID -DCLOUD_STORE_ARTIFACT_ID=$CLOUD_STORE_ARTIFACT_ID -DCLOUD_STORE_VERSION=$CLOUD_STORE_VERSION
+            mvn clean scoverage:report
       - run:
           name: Save test results
           command: |

--- a/.github/workflows/build-push-img.yml
+++ b/.github/workflows/build-push-img.yml
@@ -4,17 +4,12 @@ name: Build and Push Flink Image
 permissions:
   contents: read
   packages: write
-  
+
 on:
   push:
     tags:
       - '*'
-      
-env:
-  CLOUD_STORE_GROUP_ID: ${{ vars.CLOUD_STORE_GROUP_ID || 'org.sunbird' }}
-  CLOUD_STORE_ARTIFACT_ID: ${{ vars.CLOUD_STORE_ARTIFACT_ID || 'cloud-store-sdk_2.12' }}
-  CLOUD_STORE_VERSION: ${{ vars.CLOUD_STORE_VERSION || '1.4.6' }}
-  
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -44,13 +39,13 @@ jobs:
           maven-version: 3.8.7
 
       - name: Login Docker Registry
-        run: |        
+        run: |
           case "${{ vars.REGISTRY_PROVIDER }}" in
           "gcp")
             echo "${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}" | base64 --decode > $HOME/gcloud-key.json
             gcloud auth activate-service-account --key-file=$HOME/gcloud-key.json
             gcloud auth configure-docker ${{ secrets.REGISTRY_NAME }}
-            REGISTRY_URL=$(echo "${{ secrets.REGISTRY_URL }}" | tr '[:upper:]' '[:lower:]') 
+            REGISTRY_URL=$(echo "${{ secrets.REGISTRY_URL }}" | tr '[:upper:]' '[:lower:]')
             ;;
           "azure" | "dockerhub")
             echo "${{ secrets.REGISTRY_PASSWORD }}" | docker login "${{ secrets.REGISTRY_NAME }}" \
@@ -67,10 +62,8 @@ jobs:
 
       - name: Build flink
         run: |
-          mvn clean install -DskipTests \
-          -DCLOUD_STORE_GROUP_ID=${CLOUD_STORE_GROUP_ID}  \
-          -DCLOUD_STORE_ARTIFACT_ID=${CLOUD_STORE_ARTIFACT_ID} \
-          -DCLOUD_STORE_VERSION=${CLOUD_STORE_VERSION}
+          CSP="${{ vars.CSP || 'azure' }}"
+          mvn clean install -DskipTests -P${CSP}
 
       - name: Package flink
         working-directory: jobs-distribution
@@ -80,11 +73,12 @@ jobs:
       - name: Build Docker Image
         working-directory: jobs-distribution
         run: |
+          CSP="${{ vars.CSP || 'azure' }}"
           IMAGE_TAG=$(echo "${{ github.ref_name }}_$(echo $GITHUB_SHA | cut -c1-7)" | tr '[:upper:]' '[:lower:]')
-          docker build -t ${REGISTRY_URL}:${IMAGE_TAG} .
+          docker build --build-arg CSP=${CSP} -t ${REGISTRY_URL}:${IMAGE_TAG} .
 
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
-     
+
       - name: Push Docker Image
         run: |
           docker push ${REGISTRY_URL}:${IMAGE_TAG}

--- a/.github/workflows/pr-actions.yml
+++ b/.github/workflows/pr-actions.yml
@@ -18,10 +18,6 @@ jobs:
     outputs:
       maven-cache-key: ${{ steps.cache-maven.outputs.cache-primary-key }}
     env:
-      # Cloud storage configuration for dependencies
-      CLOUD_STORE_GROUP_ID: ${{ vars.CLOUD_STORE_GROUP_ID }}
-      CLOUD_STORE_ARTIFACT_ID: ${{ vars.CLOUD_STORE_ARTIFACT_ID }}
-      CLOUD_STORE_VERSION: ${{ vars.CLOUD_STORE_VERSION }}
       SCHEMA_BASE_PATH: ${{ vars.SCHEMA_BASE_PATH }}
       BLOB_IMAGE_CONTENT_PATH: ${{ vars.BLOB_IMAGE_CONTENT_PATH }}
     steps:
@@ -49,16 +45,10 @@ jobs:
       - name: Build root POM and job-core
         run: |
           # Install root POM without tests
-          mvn clean install -N -DskipTests \
-            -DCLOUD_STORE_GROUP_ID=$CLOUD_STORE_GROUP_ID \
-            -DCLOUD_STORE_ARTIFACT_ID=$CLOUD_STORE_ARTIFACT_ID \
-            -DCLOUD_STORE_VERSION=$CLOUD_STORE_VERSION
+          mvn clean install -N -DskipTests
           # Build jobs-core with tests and coverage
           cd jobs-core
           mvn clean install \
-            -DCLOUD_STORE_GROUP_ID=$CLOUD_STORE_GROUP_ID \
-            -DCLOUD_STORE_ARTIFACT_ID=$CLOUD_STORE_ARTIFACT_ID \
-            -DCLOUD_STORE_VERSION=$CLOUD_STORE_VERSION \
             org.jacoco:jacoco-maven-plugin:0.8.8:prepare-agent \
             test \
             org.jacoco:jacoco-maven-plugin:0.8.8:report \
@@ -82,21 +72,15 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'maven' 
+          cache: 'maven'
 
       # Run SonarQube analysis for jobs-core module
       - name: Run SonarQube Analysis for jobs-core
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          CLOUD_STORE_GROUP_ID: ${{ vars.CLOUD_STORE_GROUP_ID }}
-          CLOUD_STORE_ARTIFACT_ID: ${{ vars.CLOUD_STORE_ARTIFACT_ID }}
-          CLOUD_STORE_VERSION: ${{ vars.CLOUD_STORE_VERSION }}
         working-directory: jobs-core
         run: |
           mvn sonar:sonar \
-            -DCLOUD_STORE_GROUP_ID=$CLOUD_STORE_GROUP_ID \
-            -DCLOUD_STORE_ARTIFACT_ID=$CLOUD_STORE_ARTIFACT_ID \
-            -DCLOUD_STORE_VERSION=$CLOUD_STORE_VERSION \
             -Dsonar.projectKey=Sunbird-Knowlg_knowledge-platform-jobs \
             -Dsonar.organization=sunbird-knowlg-1 \
             -Dsonar.host.url=https://sonarcloud.io \
@@ -116,9 +100,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Cloud storage and content processing configuration
-      CLOUD_STORE_GROUP_ID: ${{ vars.CLOUD_STORE_GROUP_ID }}
-      CLOUD_STORE_ARTIFACT_ID: ${{ vars.CLOUD_STORE_ARTIFACT_ID }}
-      CLOUD_STORE_VERSION: ${{ vars.CLOUD_STORE_VERSION }}
       SCHEMA_BASE_PATH: ${{ vars.SCHEMA_BASE_PATH }}
       BLOB_IMAGE_CONTENT_PATH: ${{ vars.BLOB_IMAGE_CONTENT_PATH }}
       BLOB_VIDEO_CONTENT_PATH: ${{ vars.BLOB_VIDEO_CONTENT_PATH }}
@@ -167,9 +148,6 @@ jobs:
         run: |
           cd asset-enrichment
           mvn clean test \
-            -DCLOUD_STORE_GROUP_ID=$CLOUD_STORE_GROUP_ID \
-            -DCLOUD_STORE_ARTIFACT_ID=$CLOUD_STORE_ARTIFACT_ID \
-            -DCLOUD_STORE_VERSION=$CLOUD_STORE_VERSION \
             org.jacoco:jacoco-maven-plugin:0.8.8:prepare-agent \
             test \
             org.jacoco:jacoco-maven-plugin:0.8.8:report \
@@ -193,21 +171,15 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'maven' 
+          cache: 'maven'
 
       # Run SonarQube analysis for asset-enrichment module
       - name: Run SonarQube Analysis for asset-enrichment
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          CLOUD_STORE_GROUP_ID: ${{ vars.CLOUD_STORE_GROUP_ID }}
-          CLOUD_STORE_ARTIFACT_ID: ${{ vars.CLOUD_STORE_ARTIFACT_ID }}
-          CLOUD_STORE_VERSION: ${{ vars.CLOUD_STORE_VERSION }}
         working-directory: asset-enrichment
         run: |
           mvn sonar:sonar \
-            -DCLOUD_STORE_GROUP_ID=$CLOUD_STORE_GROUP_ID \
-            -DCLOUD_STORE_ARTIFACT_ID=$CLOUD_STORE_ARTIFACT_ID \
-            -DCLOUD_STORE_VERSION=$CLOUD_STORE_VERSION \
             -Dsonar.projectKey=Sunbird-Knowlg_knowledge-platform-jobs \
             -Dsonar.organization=sunbird-knowlg-1 \
             -Dsonar.host.url=https://sonarcloud.io \
@@ -219,13 +191,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Cloud storage and content processing configuration
-      CLOUD_STORE_GROUP_ID: ${{ vars.CLOUD_STORE_GROUP_ID }}
-      CLOUD_STORE_ARTIFACT_ID: ${{ vars.CLOUD_STORE_ARTIFACT_ID }}
-      CLOUD_STORE_VERSION: ${{ vars.CLOUD_STORE_VERSION }}
       SCHEMA_BASE_PATH: ${{ vars.SCHEMA_BASE_PATH }}
     steps:
       - uses: actions/checkout@v3
-      
+
       # Set up Java 11 for building and testing
       - name: Set up JDK11
         uses: actions/setup-java@v3
@@ -255,9 +224,6 @@ jobs:
         run: |
           cd search-indexer
           mvn clean test \
-            -DCLOUD_STORE_GROUP_ID=$CLOUD_STORE_GROUP_ID \
-            -DCLOUD_STORE_ARTIFACT_ID=$CLOUD_STORE_ARTIFACT_ID \
-            -DCLOUD_STORE_VERSION=$CLOUD_STORE_VERSION \
             org.jacoco:jacoco-maven-plugin:0.8.8:prepare-agent \
             test \
             org.jacoco:jacoco-maven-plugin:0.8.8:report \
@@ -287,15 +253,9 @@ jobs:
       - name: Run SonarQube Analysis for search-indexer
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          CLOUD_STORE_GROUP_ID: ${{ vars.CLOUD_STORE_GROUP_ID }}
-          CLOUD_STORE_ARTIFACT_ID: ${{ vars.CLOUD_STORE_ARTIFACT_ID }}
-          CLOUD_STORE_VERSION: ${{ vars.CLOUD_STORE_VERSION }}
         working-directory: search-indexer
         run: |
           mvn sonar:sonar \
-            -DCLOUD_STORE_GROUP_ID=$CLOUD_STORE_GROUP_ID \
-            -DCLOUD_STORE_ARTIFACT_ID=$CLOUD_STORE_ARTIFACT_ID \
-            -DCLOUD_STORE_VERSION=$CLOUD_STORE_VERSION \
             -Dsonar.projectKey=Sunbird-Knowlg_knowledge-platform-jobs \
             -Dsonar.organization=sunbird-knowlg-1 \
             -Dsonar.host.url=https://sonarcloud.io \
@@ -306,9 +266,6 @@ jobs:
     needs: root-pom-build-and-coverage-job-core
     runs-on: ubuntu-latest
     env:
-      CLOUD_STORE_GROUP_ID: ${{ vars.CLOUD_STORE_GROUP_ID }}
-      CLOUD_STORE_ARTIFACT_ID: ${{ vars.CLOUD_STORE_ARTIFACT_ID }}
-      CLOUD_STORE_VERSION: ${{ vars.CLOUD_STORE_VERSION }}
       SCHEMA_BASE_PATH: ${{ vars.SCHEMA_BASE_PATH }}
       CLOUD_STORAGE_CONTAINER: ${{ vars.CLOUD_STORAGE_CONTAINER }}
     steps:
@@ -338,9 +295,6 @@ jobs:
         run: |
           cd qrcode-image-generator
           mvn clean test \
-            -DCLOUD_STORE_GROUP_ID=$CLOUD_STORE_GROUP_ID \
-            -DCLOUD_STORE_ARTIFACT_ID=$CLOUD_STORE_ARTIFACT_ID \
-            -DCLOUD_STORE_VERSION=$CLOUD_STORE_VERSION \
             org.jacoco:jacoco-maven-plugin:0.8.8:prepare-agent \
             test \
             org.jacoco:jacoco-maven-plugin:0.8.8:report \
@@ -361,20 +315,14 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'maven' 
+          cache: 'maven'
 
       - name: Run SonarQube Analysis for qrcode-image-generator
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          CLOUD_STORE_GROUP_ID: ${{ vars.CLOUD_STORE_GROUP_ID }}
-          CLOUD_STORE_ARTIFACT_ID: ${{ vars.CLOUD_STORE_ARTIFACT_ID }}
-          CLOUD_STORE_VERSION: ${{ vars.CLOUD_STORE_VERSION }}
         working-directory: qrcode-image-generator
         run: |
           mvn sonar:sonar \
-            -DCLOUD_STORE_GROUP_ID=$CLOUD_STORE_GROUP_ID \
-            -DCLOUD_STORE_ARTIFACT_ID=$CLOUD_STORE_ARTIFACT_ID \
-            -DCLOUD_STORE_VERSION=$CLOUD_STORE_VERSION \
             -Dsonar.projectKey=Sunbird-Knowlg_knowledge-platform-jobs \
             -Dsonar.organization=sunbird-knowlg-1 \
             -Dsonar.host.url=https://sonarcloud.io \

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,18 +11,13 @@ on:
     - cron: '0 0 * * 1'
   workflow_dispatch: # Allow manual trigger
 
-env:
-  CLOUD_STORE_GROUP_ID: ${{ vars.CLOUD_STORE_GROUP_ID || 'org.sunbird' }}
-  CLOUD_STORE_ARTIFACT_ID: ${{ vars.CLOUD_STORE_ARTIFACT_ID || 'cloud-store-sdk_2.12' }}
-  CLOUD_STORE_VERSION: ${{ vars.CLOUD_STORE_VERSION || '1.4.6' }}
-
 jobs:
   sonarcloud-scan:
     name: SonarCloud Code Analysis
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -54,9 +49,6 @@ jobs:
           mvn clean \
             org.jacoco:jacoco-maven-plugin:0.8.8:prepare-agent \
             verify \
-            -DCLOUD_STORE_GROUP_ID=${CLOUD_STORE_GROUP_ID} \
-            -DCLOUD_STORE_ARTIFACT_ID=${CLOUD_STORE_ARTIFACT_ID} \
-            -DCLOUD_STORE_VERSION=${CLOUD_STORE_VERSION} \
             org.jacoco:jacoco-maven-plugin:0.8.8:report
 
       # Set up Java 17 for SonarCloud analysis (required by SonarQube scanner)
@@ -74,9 +66,6 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
           mvn sonar:sonar \
-            -DCLOUD_STORE_GROUP_ID=${CLOUD_STORE_GROUP_ID} \
-            -DCLOUD_STORE_ARTIFACT_ID=${CLOUD_STORE_ARTIFACT_ID} \
-            -DCLOUD_STORE_VERSION=${CLOUD_STORE_VERSION} \
             -Dsonar.projectKey=Sunbird-Knowlg_knowledge-platform-jobs \
             -Dsonar.organization=sunbird-knowlg-1 \
             -Dsonar.host.url=https://sonarcloud.io \

--- a/README.md
+++ b/README.md
@@ -307,11 +307,5 @@ To ensure the GitHub Actions workflows in this repository function correctly, th
     - `REGISTRY_PROVIDER`: Set to any value other than above (default is GHCR)
     - No additional secrets are required. The workflow uses the built-in `GITHUB_TOKEN` provided by GitHub Actions for authentication.
 
-2. **Environment Variables**:
-   - The following environment variables have be set in the repository or workflow if not set the default values will taken:
-     - `CLOUD_STORE_GROUP_ID`: The group ID for cloud storage dependencies.
-     - `CLOUD_STORE_ARTIFACT_ID`: The artifact ID for cloud storage dependencies.
-     - `CLOUD_STORE_VERSION`: The version of the cloud storage dependencies.
-
 Ensure these secrets and variables are added to the repository settings under **Settings > Secrets and variables > Actions**.
 By ensuring these prerequisites are met, the workflows in this repository will execute successfully.

--- a/jobs-core/pom.xml
+++ b/jobs-core/pom.xml
@@ -121,64 +121,21 @@
             <artifactId>junidecode</artifactId>
             <version>0.1.1</version>
         </dependency>
+        <!-- Cloud Storage SDK v2: API module (compile-time interface) -->
         <dependency>
-            <groupId>${CLOUD_STORE_GROUP_ID}</groupId>
-            <artifactId>${CLOUD_STORE_ARTIFACT_ID}</artifactId>
-            <version>${CLOUD_STORE_VERSION}</version>
+            <groupId>org.sunbird</groupId>
+            <artifactId>cloud-storage-sdk-api</artifactId>
+            <version>${cloud.storage.sdk.version}</version>
             <exclusions>
+                <!-- SLF4J 2.x excluded; project uses SLF4J 1.7.x pinned in root dependencyManagement -->
                 <exclusion>
-                    <artifactId>log4j</artifactId>
-                    <groupId>log4j</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>slf4j-log4j12</artifactId>
                     <groupId>org.slf4j</groupId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.jamesmurty.utils</groupId>
-                    <artifactId>java-xmlbuilder</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.hadoop</groupId>
-                    <artifactId>hadoop-common</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.zookeeper</groupId>
-                    <artifactId>zookeeper</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>at.yawk.lz4</groupId>
-                    <artifactId>lz4-java</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.lz4</groupId>
-                    <artifactId>lz4-java</artifactId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- Override jclouds to 2.5.0+ to fix JAVA_LETTER_OR_DIGIT compatibility issue with Guava 32.x and Java 11+ -->
-        <dependency>
-            <groupId>org.apache.jclouds</groupId>
-            <artifactId>jclouds-core</artifactId>
-            <version>2.5.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.jclouds.provider</groupId>
-            <artifactId>azureblob</artifactId>
-            <version>2.5.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.google.code.gson</groupId>
-                    <artifactId>gson</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+        <!-- CSP runtime jar is supplied by a Maven profile (-Pazure / -Paws / -Pgcp / -Poci).
+             Default profile is 'azure'. See <profiles> section at the bottom of this file. -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
@@ -411,5 +368,93 @@
 
         </plugins>
     </build>
+
+    <profiles>
+        <!-- CSP profiles: activated at build time via -P<id>.
+             Each profile bundles exactly one CSP runtime jar so the resulting fat JAR
+             contains only the SDK for the chosen cloud provider.
+             Build examples:
+               mvn clean install -DskipTests -Pazure   (default — Azure Blob Storage)
+               mvn clean install -DskipTests -Paws     (AWS S3)
+               mvn clean install -DskipTests -Pgcp     (Google Cloud Storage)
+               mvn clean install -DskipTests -Poci     (Oracle Cloud Infrastructure)
+             Note: these profiles are independent of the module-selection profiles in the
+             root pom.xml (knowlg-jobs / knowlg-core). Specify both when needed, e.g.:
+               mvn clean install -DskipTests -Paws -pl asset-enrichment -am -->
+        <profile>
+            <id>azure</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.sunbird</groupId>
+                    <artifactId>cloud-storage-sdk-azure</artifactId>
+                    <version>${cloud.storage.sdk.version}</version>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-api</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>aws</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.sunbird</groupId>
+                    <artifactId>cloud-storage-sdk-aws</artifactId>
+                    <version>${cloud.storage.sdk.version}</version>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-api</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>gcp</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.sunbird</groupId>
+                    <artifactId>cloud-storage-sdk-gcp</artifactId>
+                    <version>${cloud.storage.sdk.version}</version>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-api</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>oci</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.sunbird</groupId>
+                    <artifactId>cloud-storage-sdk-oci</artifactId>
+                    <version>${cloud.storage.sdk.version}</version>
+                    <scope>runtime</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.slf4j</groupId>
+                            <artifactId>slf4j-api</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 
 </project>

--- a/jobs-core/src/main/scala/org/sunbird/job/util/CloudStorageUtil.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/CloudStorageUtil.scala
@@ -1,8 +1,8 @@
 package org.sunbird.job.util
 
 import org.apache.commons.lang3.StringUtils
-import org.sunbird.cloud.storage.BaseStorageService
-import org.sunbird.cloud.storage.factory.{StorageConfig, StorageServiceFactory}
+import org.sunbird.cloud.storage.{IStorageService, StorageConfig, StorageServiceFactory}
+import org.sunbird.cloud.storage.StorageConfig.StorageType
 import org.sunbird.job.BaseJobConfig
 
 import java.io.File
@@ -10,18 +10,45 @@ import java.io.File
 class CloudStorageUtil(config: BaseJobConfig) extends Serializable {
 
   val cloudStorageType: String = config.getString("cloud_storage_type", "azure")
-  var storageService: BaseStorageService = null
+  var storageService: IStorageService = null
   val container: String = getContainerName
 
   @throws[Exception]
-  def getService: BaseStorageService = {
+  def getService: IStorageService = {
     if (null == storageService) {
-      val storageKey = config.getString("cloud_storage_key", "")
+      val storageKey    = config.getString("cloud_storage_key", "")
       val storageSecret = config.getString("cloud_storage_secret", "")
-      val endPoint = config.getString("cloud_storage_endpoint", "")
-      // TODO: endPoint defined to support "cephs3". Make code changes after cloud-store-sdk 2.11 support it.
-      val storageEndPoint = if (StringUtils.isNotBlank(endPoint)) Option(endPoint) else None
-      storageService = StorageServiceFactory.getStorageService(StorageConfig(cloudStorageType, storageKey, storageSecret,storageEndPoint))
+      val endPoint      = config.getString("cloud_storage_endpoint", "")
+      val region        = config.getString("cloud_storage_region", "")
+      val authTypeStr   = config.getString("cloud_storage_auth_type", "ACCESS_KEY").toUpperCase
+
+      val storageType = cloudStorageType.toLowerCase match {
+        case "aws"    => StorageType.AWS
+        case "azure"  => StorageType.AZURE
+        case "gcloud" => StorageType.GCLOUD
+        case "oci"    => StorageType.OCI
+        case "cephs3" => StorageType.CEPHS3
+        case other    => throw new Exception(s"Unsupported cloud storage type: $other")
+      }
+
+      val authType = StorageConfig.AuthType.valueOf(authTypeStr)
+
+      val builder = StorageConfig.builder(storageType)
+        .storageKey(storageKey)
+        .authType(authType)
+
+      // For ACCESS_KEY auth: provide the static secret from configuration.
+      // For OIDC / IAM / IAM_ROLE / INSTANCE_PROFILE: the cloud SDK resolves credentials
+      // automatically via Workload Identity, Managed Identity, or the default credential chain —
+      // no static secret is needed (and setting it may confuse some providers).
+      if (authType == StorageConfig.AuthType.ACCESS_KEY) {
+        builder.storageSecret(storageSecret)
+      }
+
+      if (StringUtils.isNotBlank(endPoint)) builder.endPoint(endPoint)
+      if (StringUtils.isNotBlank(region))   builder.region(region)
+
+      storageService = StorageServiceFactory.getStorageService(builder.build())
     }
     storageService
   }
@@ -34,33 +61,33 @@ class CloudStorageUtil(config: BaseJobConfig) extends Serializable {
   }
 
   def uploadFile(folderName: String, file: File, slug: Option[Boolean] = Option(true), container: String = container): Array[String] = {
-    val slugFile = if (slug.getOrElse(true)) Slug.createSlugFile(file) else file
+    val slugFile  = if (slug.getOrElse(true)) Slug.createSlugFile(file) else file
     val objectKey = folderName + "/" + slugFile.getName
-    val url = getService.upload(container, slugFile.getAbsolutePath, objectKey, Option.apply(false), Option.apply(1), Option.apply(5), Option.empty)
+    val url       = getService.upload(container, slugFile.getAbsolutePath, objectKey, false, 1, 5, null)
     Array[String](objectKey, url)
   }
 
   def copyObjectsByPrefix(sourcePrefix: String, destinationPrefix: String, isFolder: Boolean): Unit = {
-    getService.copyObjects(container, sourcePrefix, container, destinationPrefix, Option.apply(isFolder))
+    getService.copyObjects(container, sourcePrefix, container, destinationPrefix, isFolder)
   }
 
   def getURI(prefix: String, isDirectory: Option[Boolean]): String = {
-    getService.getUri(getContainerName, prefix, isDirectory)
+    getService.getUri(getContainerName, prefix, isDirectory.getOrElse(false))
   }
 
   def uploadDirectory(folderName: String, directory: File, slug: Option[Boolean] = Option(true)): Array[String] = {
-    val slugFile = if (slug.getOrElse(true)) Slug.createSlugFile(directory) else directory
+    val slugFile  = if (slug.getOrElse(true)) Slug.createSlugFile(directory) else directory
     val objectKey = folderName + File.separator
-    val url = getService.upload(getContainerName, slugFile.getAbsolutePath, objectKey, Option.apply(true), Option.apply(1), Option.apply(5), Option.empty)
+    val url       = getService.upload(getContainerName, slugFile.getAbsolutePath, objectKey, true, 1, 5, null)
     Array[String](objectKey, url)
   }
 
   def deleteFile(key: String, isDirectory: Option[Boolean] = Option(false)): Unit = {
-    getService.deleteObject(getContainerName, key, isDirectory)
+    getService.deleteObject(getContainerName, key, isDirectory.getOrElse(false))
   }
 
   def downloadFile(downloadPath: String, file: String, slug: Option[Boolean] = Option(false)): Unit = {
-    getService.download(getContainerName, file, downloadPath, slug)
+    getService.download(getContainerName, file, downloadPath, slug.getOrElse(false))
   }
 
 }

--- a/jobs-distribution/Dockerfile
+++ b/jobs-distribution/Dockerfile
@@ -1,5 +1,14 @@
 FROM sunbird/flink:1.13.5-scala_2.12-java11
 
+# CSP selection: pass --build-arg CSP=<azure|aws|gcp|oci> at image build time (default: azure).
+# The Maven build must have been run with the matching profile (-Pazure / -Paws / -Pgcp / -Poci)
+# so that exactly one CSP runtime jar is present in the distribution; Java ServiceLoader picks it up automatically.
+# cloud_storage_auth_type defaults to OIDC (Kubernetes Workload Identity).
+# Override via K8s ConfigMap or `docker run -e` for local ACCESS_KEY-based development.
+ARG CSP=azure
+ENV cloud_storage_type=${CSP}
+ENV cloud_storage_auth_type=OIDC
+
 USER root
 RUN apt-get update
 RUN apt-get update && apt-get dist-upgrade -y && \

--- a/kubernets/pipelines/build/Jenkinsfile
+++ b/kubernets/pipelines/build/Jenkinsfile
@@ -20,15 +20,11 @@ node('build-slave') {
                 commit_hash = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
                 build_tag = sh(script: "echo " + params.github_release_tag.split('/')[-1] + "_" + commit_hash + "_" + env.BUILD_NUMBER, returnStdout: true).trim()
                 echo "build_tag: " + build_tag
-                cloud_store_group_id = params.CLOUD_STORE_GROUP_ID
-                cloud_store_artifact_id = params.CLOUD_STORE_ARTIFACT_ID
-                cloud_store_version = params.CLOUD_STORE_VERSION
-
                 stage('Build') {
                     env.NODE_ENV = "build"
                     print "Environment will be : ${env.NODE_ENV}"
                     sh '/opt/apache-maven-3.6.3/bin/mvn3.6 -v'
-                    sh '/opt/apache-maven-3.6.3/bin/mvn3.6 clean install -DskipTests -DCLOUD_STORE_GROUP_ID=' + cloud_store_group_id + ' -DCLOUD_STORE_ARTIFACT_ID=' + cloud_store_artifact_id + ' -DCLOUD_STORE_VERSION=' + cloud_store_version
+                    sh '/opt/apache-maven-3.6.3/bin/mvn3.6 clean install -DskipTests'
                   
                 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,10 @@
 		<netty.version>4.1.129.Final</netty.version>
 		<jetty.version>9.4.57.v20241219</jetty.version>
 		<jackson.version>2.18.6</jackson.version>
+		<!-- Pin SLF4J to 1.7.x: Flink 1.13.6 uses SLF4J 1.7.x; logback 1.2.x requires SLF4J 1.7.x.
+		     The new cloud-storage-sdk-api 2.x declares slf4j-api 2.x transitively — override it here. -->
+		<slf4j.version>1.7.36</slf4j.version>
+		<cloud.storage.sdk.version>2.0.1</cloud.storage.sdk.version>
 	</properties>
 
 	<repositories>
@@ -88,6 +92,13 @@
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>
+			<!-- SLF4J 1.7.x: Flink 1.13.6 uses SLF4J 1.7.x; logback 1.2.x requires it.
+			     Prevents cloud-storage-sdk 2.x transitive SLF4J 2.x from winning. -->
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-api</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
 			<dependency>
 				<groupId>javax.ws.rs</groupId>
 				<artifactId>javax.ws.rs-api</artifactId>


### PR DESCRIPTION
## Summary

- **Replace** the old `cloud-store-sdk_2.12:1.5.0` (Scala, single-JAR, resolved at build time via `-DCLOUD_STORE_*` flags) with the new multi-module Java SDK `cloud-storage-sdk:2.0.1` (`-api` compile artifact + one CSP runtime JAR selected by Maven profile)
- **Add Maven CSP profiles** (`azure` active by default, `aws`, `gcp`, `oci`) in `jobs-core/pom.xml` so exactly one CSP runtime JAR is packaged per build
- **Update `CloudStorageUtil`** to the new `IStorageService` / `StorageConfig.builder` / `StorageType` / `AuthType` API; adds `OIDC` / `IAM` workload-identity support alongside the existing `ACCESS_KEY` path
- **Remove obsolete `-DCLOUD_STORE_*` build flags** from all CI/CD pipelines (GitHub Actions, CircleCI, Jenkinsfile) — SDK is now a direct Maven dependency
- **Update `jobs-distribution/Dockerfile`** to accept `--build-arg CSP=<azure|aws|gcp|oci>` (default `azure`) and set `cloud_storage_type` + `cloud_storage_auth_type=OIDC` as image env vars, consistent with the pattern adopted in `knowledge-platform` services

## Changed files

| File | Change |
|---|---|
| `pom.xml` | Add `cloud.storage.sdk.version=2.0.1` property |
| `jobs-core/pom.xml` | Replace old SDK dep with `cloud-storage-sdk-api` (compile) + CSP profiles (runtime) |
| `jobs-core/.../CloudStorageUtil.scala` | Rewrite to new `IStorageService` / `StorageConfig.builder` / `AuthType` API |
| `jobs-distribution/Dockerfile` | Add `ARG CSP` / `ENV cloud_storage_type` / `ENV cloud_storage_auth_type=OIDC` |
| `.github/workflows/build-push-img.yml` | Pass `-P${CSP}` to Maven and `--build-arg CSP=${CSP}` to Docker |
| `.github/workflows/pr-actions.yml` | Remove `CLOUD_STORE_*` env vars and flags |
| `.github/workflows/sonarcloud.yml` | Remove `CLOUD_STORE_*` env vars and flags |
| `.circleci/config.yml` | Remove `CLOUD_STORE_*` flags from `mvn` command |
| `kubernets/pipelines/build/Jenkinsfile` | Remove `cloud_store_*` variable assignments |
| `README.md` | Remove obsolete `CLOUD_STORE_*` environment variable section |

## Build instructions

```bash
# Azure (default — no flag needed)
mvn clean install -DskipTests

# Other CSPs
mvn clean install -DskipTests -Paws
mvn clean install -DskipTests -Pgcp
mvn clean install -DskipTests -Poci
```

```bash
# Docker — CSP must match the Maven profile used above
cd jobs-distribution
docker build --build-arg CSP=azure -t knowledge-platform-jobs:latest .
```

## Test plan

- [ ] `mvn clean install -DskipTests` passes with azure profile active by default
- [ ] `mvn clean install -DskipTests -Paws` passes and only `cloud-storage-sdk-aws` is in the distribution
- [ ] Docker build succeeds with `--build-arg CSP=azure`; container has `cloud_storage_type=azure` and `cloud_storage_auth_type=OIDC` set
- [ ] `asset-enrichment` integration tests pass with real cloud credentials (`CLOUD_STORAGE_TYPE`, `CLOUD_STORAGE_KEY`, `CLOUD_STORAGE_SECRET`, `CLOUD_STORAGE_CONTAINER`, `BLOB_IMAGE_CONTENT_PATH`, `SCHEMA_BASE_PATH`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)