### PR TITLE
chore(docker): add .dockerignore to reduce build context

### DIFF
--- a/jobs-distribution/.dockerignore
+++ b/jobs-distribution/.dockerignore
@@ -1,0 +1,7 @@
+# Exclude everything in target/ except the distribution tarball
+target/*
+!target/jobs-distribution-1.0.tar.gz
+
+# Not needed by the Dockerfile
+src/
+pom.xml


### PR DESCRIPTION
… to ~50 MB

Exclude the unpacked target/ tree (keep only the distribution tarball) and src/ so the Docker daemon only receives what the Dockerfile actually needs: target/jobs-distribution-1.0.tar.gz and the lib/ JARs.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules