### PR TITLE
fix: update test metric reporter for Flink 1.18 API

### DIFF
--- a/jobs-core/src/test/resources/META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory
+++ b/jobs-core/src/test/resources/META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory
@@ -1,0 +1,1 @@
+org.sunbird.spec.BaseMetricsReporterFactory

--- a/jobs-core/src/test/scala/org/sunbird/spec/BaseMetricsReporter.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/BaseMetricsReporter.scala
@@ -1,8 +1,10 @@
 package org.sunbird.spec
 
-import org.apache.flink.metrics.{Gauge, Metric, MetricConfig, MetricGroup}
-import org.apache.flink.metrics.reporter.MetricReporter
+import org.apache.flink.metrics.Gauge
+import org.apache.flink.metrics.reporter.{MetricReporter, MetricReporterFactory}
+import org.apache.flink.metrics.{Metric, MetricConfig, MetricGroup}
 
+import java.util.Properties
 import scala.collection.mutable
 
 class BaseMetricsReporter extends MetricReporter {
@@ -23,6 +25,12 @@ class BaseMetricsReporter extends MetricReporter {
   override def notifyOfRemovedMetric(metric: Metric, metricName: String, group: MetricGroup): Unit = {}
 }
 
+class BaseMetricsReporterFactory extends MetricReporterFactory {
+  override def createMetricReporter(properties: Properties): MetricReporter = {
+    new BaseMetricsReporter()
+  }
+}
+
 object BaseMetricsReporter {
-  val gaugeMetrics: mutable.Map[String, Gauge[Long]] = mutable.Map[String, Gauge[Long]]()
+  val gaugeMetrics :  mutable.Map[String,  Gauge[Long]] = mutable.Map[String,  Gauge[Long]]()
 }

--- a/jobs-core/src/test/scala/org/sunbird/spec/BaseTestSpec.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/BaseTestSpec.scala
@@ -8,8 +8,8 @@ class BaseTestSpec extends FlatSpec with Matchers with BeforeAndAfterAll with Mo
 
   def testConfiguration(): Configuration = {
     val config = new Configuration()
-    config.setString("metrics.reporter", "job_metrics_reporter")
-    config.setString("metrics.reporter.job_metrics_reporter.class", classOf[BaseMetricsReporter].getName)
+    config.setString("metrics.reporters", "job_metrics_reporter")
+    config.setString("metrics.reporter.job_metrics_reporter.factory.class", classOf[BaseMetricsReporterFactory].getName)
     config
   }
 


### PR DESCRIPTION
## Summary

Flink 1.18 dropped support for direct `MetricReporter` class loading via `metrics.reporter.<name>.class`. Reporters must now be loaded through `MetricReporterFactory` via Java SPI (`ServiceLoader`). This caused all test assertions on gauge metrics to fail with `key not found` because the `BaseMetricsReporter` was never registered.

### Changes

- **`BaseMetricsReporter.scala`**: Add `BaseMetricsReporterFactory` implementing `MetricReporterFactory`
- **`BaseTestSpec.scala`**: Update config keys:
  - `metrics.reporter` → `metrics.reporters` (plural, required in Flink 1.14+)
  - `metrics.reporter.<name>.class` → `metrics.reporter.<name>.factory.class`
- **`META-INF/services/org.apache.flink.metrics.reporter.MetricReporterFactory`**: SPI registration file so Flink's `ServiceLoader` discovers the factory at test runtime

### Root Cause

In Flink 1.18's `ReporterSetup.loadReporter()`, the `.class` config path logs a warning and returns `Optional.empty()`:
> "The reporter configuration of '{}' configures the reporter class, which is a no longer supported approach to configure reporters. Please configure a factory class instead."

The factory is discovered via `ServiceLoader.load(MetricReporterFactory.class)` in `getAllReporterFactories()`, which requires the SPI file in `META-INF/services/`.

## Test Plan

- [x] Verified gauge metrics are correctly registered and asserted in test specs
- [ ] Run full test suite to verify all test specs that assert on `BaseMetricsReporter.gaugeMetrics`

🤖 Generated with [Claude Code](https://claude.com/claude-code)