### PR TITLE
feat: Add Dependabot configuration and dependency submission workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  # Root pom.xml is the parent for all Maven submodules (Flink jobs, Scala/Java)
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"        # 30 min after dependency-submission workflow (03:00 UTC)
+      timezone: "UTC"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      jackson:
+        patterns:
+          - "com.fasterxml.jackson.*:*"
+      netty:
+        patterns:
+          - "io.netty:*"
+      jetty:
+        patterns:
+          - "org.eclipse.jetty:*"
+      apache-commons:
+        patterns:
+          - "org.apache.commons:*"
+          - "commons-*:*"
+
+  # Keep GitHub Actions workflow action versions updated
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "03:30"
+      timezone: "UTC"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,32 @@
+name: Dependency Submission
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'          # 03:00 UTC every Monday — runs before Dependabot (03:30)
+  push:
+    branches: [master]
+    paths:
+      - '**/pom.xml'
+  pull_request:
+    branches: [master]
+    paths:
+      - '**/pom.xml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  submit-maven:
+    name: Submit Maven dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'maven'
+      - uses: advanced-security/maven-dependency-submission-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary                                                                                                                                                                          
                                                         
  - Enables automated dependency updates for Maven and GitHub Actions via Dependabot, reducing manual effort to track and patch vulnerable or outdated dependencies.
  - Adds a weekly dependency submission workflow so GitHub's Dependency Graph reflects all Maven transitive dependencies before Dependabot runs, improving alert accuracy.            
                                                                                                                                                                          
  ## Changes                                                                                                                                                                          
                                                         
  - Add `.github/dependabot.yml` with weekly Maven updates (Monday 03:30 UTC), grouped by library family (jackson, netty, jetty, apache-commons), plus weekly GitHub Actions version  
  updates                                                                                                                                                                             
  - Add `.github/workflows/dependency-submission.yml` to submit the full Maven dependency tree to GitHub on push/PR to master when `pom.xml` files change, and on a weekly schedule at
   03:00 UTC (30 min before Dependabot)                                                                                                                                               
                                                                                                                                                                                      
  ## How to Test
                                                                                                                                                                                      
  1. Merge this PR — GitHub will surface Dependabot as enabled under **Settings → Security & analysis → Dependabot**
  2. Trigger the `Dependency Submission` workflow manually via **Actions → Dependency Submission → Run workflow** and verify it completes successfully                                
  3. After the next Monday at 03:30 UTC, confirm a Dependabot PR (or "up to date" notice) appears for Maven dependencies                              
                                                                                                                                                                                      
  ## Checklist                                                                                                                                                                        
                                                                                                                                                                                      
  - [ ] Tests added or updated                                                                                                                                                        
  - [ ] Documentation updated (if public API or behavior changed)
  - [ ] No breaking changes — or breaking changes noted with `!` in title and explained in Summary
  - [ ] Reviewed my own diff before requesting review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured Dependabot for automated weekly dependency updates with version grouping for Maven dependencies and GitHub Actions.
  * Added GitHub Actions workflow for Maven dependency submission with advanced security integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->