### PR TITLE
feat: migrate knowledge-platform-jobs from Elasticsearch 7.10.2 to OpenSearch 2.19.5

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,15 +1,16 @@
 services:
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+    image: opensearchproject/opensearch:2.19.5
     container_name: sunbird_es
     ports:
       - "9200:9200"
       - "9300:9300"
     environment:
       - discovery.type=single-node
+      - plugins.security.disabled=true
     volumes:
-      - es-data:/usr/share/elasticsearch/data
+      - es-data:/usr/share/opensearch/data
 
   yugabyte:
     image: yugabytedb/yugabyte:2025.2.0.1-b1

--- a/jobs-core/pom.xml
+++ b/jobs-core/pom.xml
@@ -236,9 +236,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.elasticsearch.client</groupId>
-            <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>7.10.2</version>
+            <groupId>org.opensearch.client</groupId>
+            <artifactId>opensearch-rest-high-level-client</artifactId>
+            <version>2.19.5</version>
         </dependency>
         <dependency>
             <groupId>com.twitter</groupId>

--- a/jobs-core/src/main/scala/org/sunbird/job/util/ElasticSearchUtil.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/ElasticSearchUtil.scala
@@ -7,16 +7,16 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.commons.lang3.StringUtils
 import org.apache.http.HttpHost
 import org.apache.http.client.config.RequestConfig
-import org.elasticsearch.action.admin.indices.alias.Alias
-import org.elasticsearch.action.bulk.BulkRequest
-import org.elasticsearch.action.delete.DeleteRequest
-import org.elasticsearch.action.get.GetRequest
-import org.elasticsearch.action.index.IndexRequest
-import org.elasticsearch.action.update.UpdateRequest
-import org.elasticsearch.client.indices.CreateIndexRequest
-import org.elasticsearch.client.{Request, RequestOptions, Response, RestClient, RestClientBuilder, RestHighLevelClient}
-import org.elasticsearch.common.settings.Settings
-import org.elasticsearch.common.xcontent.XContentType
+import org.opensearch.action.admin.indices.alias.Alias
+import org.opensearch.action.bulk.BulkRequest
+import org.opensearch.action.delete.DeleteRequest
+import org.opensearch.action.get.GetRequest
+import org.opensearch.action.index.IndexRequest
+import org.opensearch.action.update.UpdateRequest
+import org.opensearch.client.indices.CreateIndexRequest
+import org.opensearch.client.{Request, RequestOptions, Response, RestClient, RestClientBuilder, RestHighLevelClient}
+import org.opensearch.common.settings.Settings
+import org.opensearch.common.xcontent.XContentType
 import org.slf4j.LoggerFactory
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 

--- a/jobs-core/src/test/scala/org/sunbird/spec/ElasticSearchUtilSpec.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/ElasticSearchUtilSpec.scala
@@ -1,7 +1,7 @@
 package org.sunbird.spec
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.elasticsearch.action.index.IndexResponse
+import org.opensearch.action.index.IndexResponse
 import org.scalatest.{FlatSpec, Matchers}
 import org.sunbird.job.util.ElasticSearchUtil
 

--- a/jobs-distribution/pom.xml
+++ b/jobs-distribution/pom.xml
@@ -113,6 +113,7 @@
                             <goal>single</goal>
                         </goals>
                         <configuration>
+                            <appendAssemblyId>false</appendAssemblyId>
                             <descriptors>
                                 <descriptor>src/main/assembly/src.xml</descriptor>
                             </descriptors>

--- a/jobs-distribution/src/main/assembly/src.xml
+++ b/jobs-distribution/src/main/assembly/src.xml
@@ -1,4 +1,5 @@
 <assembly>
+  <id>distribution</id>
   <includeBaseDirectory>false</includeBaseDirectory>
   <formats>
     <format>tar.gz</format>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
 		<!-- maven specific properties -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<scala.version>2.12</scala.version>
-		<scala.maj.version>2.12.11</scala.maj.version>
+		<scala.maj.version>2.12.19</scala.maj.version>
 		<flink.version>1.18.1</flink.version>
 		<kafka.version>3.9.1</kafka.version>
 		<jackson-jaxrs.version>1.9.13</jackson-jaxrs.version>

--- a/pom.xml
+++ b/pom.xml
@@ -333,6 +333,27 @@
 						<excludedPackages>org.sunbird.incredible</excludedPackages>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<version>3.2.1</version>
+					<executions>
+						<execution>
+							<id>enforce-java</id>
+							<goals>
+								<goal>enforce</goal>
+							</goals>
+							<configuration>
+								<rules>
+									<requireJavaVersion>
+										<version>[11,)</version>
+										<message>Build requires Java 11 or higher (OpenSearch 2.19.5 client requires Java 11+ bytecode)</message>
+									</requireJavaVersion>
+								</rules>
+							</configuration>
+						</execution>
+					</executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>

--- a/transaction-event-processor/src/main/scala/org/sunbird/job/transaction/task/TransactionEventProcessorConfig.scala
+++ b/transaction-event-processor/src/main/scala/org/sunbird/job/transaction/task/TransactionEventProcessorConfig.scala
@@ -212,10 +212,10 @@ class TransactionEventProcessorConfig(override val config: Config)
     else false
   val esImage: String =
     if (config.hasPath("es.image")) config.getString("es.image")
-    else "docker.elastic.co/elasticsearch/elasticsearch"
+    else "opensearchproject/opensearch"
   val esImageTag: String =
     if (config.hasPath("es.imageTag")) config.getString("es.imageTag")
-    else "7.10.2"
+    else "2.19.5"
   val esPorts: util.List[String] =
     if (config.hasPath("es.ports")) config.getStringList("es.ports")
     else List("9200:9200").asJava
@@ -224,13 +224,13 @@ class TransactionEventProcessorConfig(override val config: Config)
     else "-Xms128m -Xmx512m"
   val esJavaOptsKey: String =
     if (config.hasPath("es.javaOptsKey")) config.getString("es.javaOptsKey")
-    else "ES_JAVA_OPTS"
+    else "OPENSEARCH_JAVA_OPTS"
   val xpackSecurityEnabled: String =
     if (config.hasPath("es.xpackSecurityEnabled"))
       config.getString("es.xpackSecurityEnabled")
-    else "false"
+    else "true"
   val xpackSecurityKey: String =
     if (config.hasPath("es.xpackSecurityKey"))
       config.getString("es.xpackSecurityKey")
-    else "xpack.security.enabled"
+    else "plugins.security.disabled"
 }

--- a/transaction-event-processor/src/main/scala/org/sunbird/job/transaction/task/TransactionEventProcessorConfig.scala
+++ b/transaction-event-processor/src/main/scala/org/sunbird/job/transaction/task/TransactionEventProcessorConfig.scala
@@ -225,6 +225,8 @@ class TransactionEventProcessorConfig(override val config: Config)
   val esJavaOptsKey: String =
     if (config.hasPath("es.javaOptsKey")) config.getString("es.javaOptsKey")
     else "OPENSEARCH_JAVA_OPTS"
+  // OpenSearch: plugins.security.disabled={true|false}. "true" disables security (default for local dev).
+  // Despite legacy field names, value "true" maps to plugins.security.disabled=true (security OFF).
   val xpackSecurityEnabled: String =
     if (config.hasPath("es.xpackSecurityEnabled"))
       config.getString("es.xpackSecurityEnabled")

--- a/transaction-event-processor/src/test/resources/search_indexer_test.conf
+++ b/transaction-event-processor/src/test/resources/search_indexer_test.conf
@@ -46,11 +46,11 @@ restrict {
 }
 
 es {
-  image = "docker.elastic.co/elasticsearch/elasticsearch"
-  imageTag = "7.10.2"
+  image = "opensearchproject/opensearch"
+  imageTag = "2.19.5"
   ports = ["9200:9200"]
-  javaOptsKey = "ES_JAVA_OPTS"
+  javaOptsKey = "OPENSEARCH_JAVA_OPTS"
   javaOpts = "-Xms128m -Xmx512m"
-  xpackSecurityKey = "xpack.security.enabled"
-  xpackSecurityEnabled = "false"
+  xpackSecurityKey = "plugins.security.disabled"
+  xpackSecurityEnabled = "true"
 }

--- a/transaction-event-processor/src/test/resources/test.conf
+++ b/transaction-event-processor/src/test/resources/test.conf
@@ -66,11 +66,11 @@ janusgraph {
 }
 
 es {
-  image = "docker.elastic.co/elasticsearch/elasticsearch"
-  imageTag = "7.10.2"
+  image = "opensearchproject/opensearch"
+  imageTag = "2.19.5"
   ports = ["9200:9200"]
-  javaOptsKey = "ES_JAVA_OPTS"
+  javaOptsKey = "OPENSEARCH_JAVA_OPTS"
   javaOpts = "-Xms128m -Xmx512m"
-  xpackSecurityKey = "xpack.security.enabled"
-  xpackSecurityEnabled = "false"
+  xpackSecurityKey = "plugins.security.disabled"
+  xpackSecurityEnabled = "true"
 }

--- a/transaction-event-processor/src/test/scala/org/sunbird/job/spec/SearchIndexerTaskTestSpec.scala
+++ b/transaction-event-processor/src/test/scala/org/sunbird/job/spec/SearchIndexerTaskTestSpec.scala
@@ -9,7 +9,7 @@ import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.apache.http.HttpHost
-import org.elasticsearch.client.{Request, RestClient, RestClientBuilder}
+import org.opensearch.client.{Request, RestClient, RestClientBuilder}
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito
 import org.mockito.Mockito.{doNothing, times, verify, when}
@@ -60,6 +60,7 @@ class SearchIndexerTaskTestSpec extends BaseTestSpec {
     mock[ElasticSearchUtil](Mockito.withSettings().serializable())
   var elasticContainer = new ElasticsearchContainer(
     DockerImageName.parse(jobConfig.esImage).withTag(jobConfig.esImageTag)
+      .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch")
   )
   var restClient: RestClient = _
   val defCache = new DefinitionCache()

--- a/transaction-event-processor/src/test/scala/org/sunbird/job/spec/TransactionEventProcessorTaskTestSpec.scala
+++ b/transaction-event-processor/src/test/scala/org/sunbird/job/spec/TransactionEventProcessorTaskTestSpec.scala
@@ -202,13 +202,13 @@ class TransactionEventProcessorTaskTestSpec extends BaseTestSpec {
     server.start(9200)
     server.enqueue(
       new MockResponse()
-        .setHeader("X-Elastic-Product", "Elasticsearch")
+        .setHeader("X-Opensearch-Product", "OpenSearch")
         .setHeader(
           "Content-Type",
           "application/json"
         )
         .setBody(
-          """{"name": "MacBook-Air.local","cluster_name": "elasticsearch","cluster_uuid": "9ra4wTGZSamseO3I99w","version": {"number": "7.10.2","build_flavor": "default","build_type": "tar","build_hash": "2b211dbb8bfd7f5b44d356bdfe54b1050c13","build_date": "2023-08-31T17:33:19.958690787Z","build_snapshot": false,"lucene_version": "8.11.1","minimum_wire_compatibility_version": "6.8.0","minimum_index_compatibility_version": "6.0.0-beta1"},"tagline": "You Know, for Search"}
+          """{"name": "MacBook-Air.local","cluster_name": "opensearch","cluster_uuid": "9ra4wTGZSamseO3I99w","version": {"number": "2.19.5","build_flavor": "default","build_type": "tar","build_hash": "2b211dbb8bfd7f5b44d356bdfe54b1050c13","build_date": "2023-08-31T17:33:19.958690787Z","build_snapshot": false,"lucene_version": "9.10.0","minimum_wire_compatibility_version": "7.10.0","minimum_index_compatibility_version": "7.0.0"},"tagline": "The OpenSearch Project: https://opensearch.org/"}
         |,{"_index":"kp_audit_log_2018_7","_type":"_doc","_id":"HLZ-1ngBtZ15DPx6ENjU","_version":1,"result":"created","_shards":{"total":2,"successful":0,"failed":1},"_seq_no":1,"_primary_term":1}""".stripMargin
         )
     )
@@ -240,13 +240,13 @@ class TransactionEventProcessorTaskTestSpec extends BaseTestSpec {
   "TransactionEventProcessorStreamTask" should "generate audit history indexer event" in {
     server.enqueue(
       new MockResponse()
-        .setHeader("X-Elastic-Product", "Elasticsearch")
+        .setHeader("X-Opensearch-Product", "OpenSearch")
         .setHeader(
           "Content-Type",
           "application/json"
         )
         .setBody(
-          """{"name": "MacBook-Air.local","cluster_name": "elasticsearch","cluster_uuid": "9ra4wTGZEFPeO3I99w","version": {"number": "7.10.2","build_flavor": "default","build_type": "tar","build_hash": "2b211dbb8bf7f5b44d356bdfe54b1050c13","build_date": "2023-08-31T17:33:19.958690787Z","build_snapshot": false,"lucene_version": "8.11.1","minimum_wire_compatibility_version": "6.8.0","minimum_index_compatibility_version": "6.0.0-beta1"},"tagline": "You Know, for Search"}
+          """{"name": "MacBook-Air.local","cluster_name": "opensearch","cluster_uuid": "9ra4wTGZEFPeO3I99w","version": {"number": "2.19.5","build_flavor": "default","build_type": "tar","build_hash": "2b211dbb8bf7f5b44d356bdfe54b1050c13","build_date": "2023-08-31T17:33:19.958690787Z","build_snapshot": false,"lucene_version": "9.10.0","minimum_wire_compatibility_version": "7.10.0","minimum_index_compatibility_version": "7.0.0"},"tagline": "The OpenSearch Project: https://opensearch.org/"}
         |,{"_index":"kp_audit_log_2018_7","_type":"_doc","_id":"HLZ-1ngBtZ15DPx6ENjU","_version":1,"result":"created","_shards":{"total":2,"successful":1,"failed":0},"_seq_no":1,"_primary_term":1}""".stripMargin
         )
     )

--- a/video-stream-generator/src/main/scala/org/sunbird/job/videostream/helpers/AwsSignUtils.scala
+++ b/video-stream-generator/src/main/scala/org/sunbird/job/videostream/helpers/AwsSignUtils.scala
@@ -60,7 +60,6 @@ object AwsSignUtils {
 
 	def uriEncode(input: Array[Char], encodeSlash: Boolean): String = {
 		val result: StringBuilder = new StringBuilder()
-		var i: Int = 0
 		for (i <- 0 until input.length) {
 			val ch = input(i)
 			if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' || ch == '~' || ch == '.') {

--- a/video-stream-generator/src/main/scala/org/sunbird/job/videostream/helpers/AwsSignUtils.scala
+++ b/video-stream-generator/src/main/scala/org/sunbird/job/videostream/helpers/AwsSignUtils.scala
@@ -61,8 +61,8 @@ object AwsSignUtils {
 	def uriEncode(input: Array[Char], encodeSlash: Boolean): String = {
 		val result: StringBuilder = new StringBuilder()
 		var i: Int = 0
-		for (i <- 0 to input.length()) {
-			val ch = input.charAt(i)
+		for (i <- 0 until input.length) {
+			val ch = input(i)
 			if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || (ch >= '0' && ch <= '9') || ch == '_' || ch == '-' || ch == '~' || ch == '.') {
 				result.append(ch)
 			} else if (ch == '/') {


### PR DESCRIPTION
## Description

Migrates `knowledge-platform-jobs` — the Flink-based streaming job layer — from Elasticsearch 7.10.2 to OpenSearch 2.19.5. All jobs write to the search index via a single shared abstraction (`ElasticSearchUtil.scala` in `jobs-core`); changing the client dependency and imports there propagates to all consuming modules automatically.

This is a prerequisite for the platform's Hybrid Search initiative, which requires native k-NN / vector indexing support available in OpenSearch 2.x.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / Technical Debt
- [ ] Test case addition/update

## Modules Affected

- `jobs-core` (client + shared util)
- `transaction-event-processor` (test infra)
- `video-stream-generator` (pre-existing build fix)
- `jobs-distribution` (assembly config)

## Changes

**Core client migration:**
- Replace `org.elasticsearch.client:elasticsearch-rest-high-level-client:7.10.2`
  with `org.opensearch.client:opensearch-rest-high-level-client:2.19.5` in `jobs-core/pom.xml`
- Rename all `org.elasticsearch.*` imports to `org.opensearch.*` in `ElasticSearchUtil.scala`
  and `ElasticSearchUtilSpec.scala`
- No business logic or API call-site changes required — OpenSearch 2.x preserves full
  method-signature parity with the ES 7.10.2 client under the `org.opensearch.*` namespace

**Docker and test infrastructure:**
- Replace `docker.elastic.co/elasticsearch/elasticsearch:7.10.2` with
  `opensearchproject/opensearch:2.19.5` in `docker-compose.yml`
- Disable security plugin for local dev via `plugins.security.disabled=true`
- Update testcontainer image, `OPENSEARCH_JAVA_OPTS`, and security env vars in
  `search_indexer_test.conf` and `test.conf`
- Use `asCompatibleSubstituteFor` in `SearchIndexerTaskTestSpec` to run
  `ElasticsearchContainer` with the OpenSearch image
- Service name kept as `elasticsearch` to avoid config churn across env files

**Scala 2.12.19 upgrade and build fixes:**
- Bump `scala.maj.version` from `2.12.11` → `2.12.19` in root `pom.xml`
  — OpenSearch 2.x JARs use `CONSTANT_Dynamic` (Java 11 constant pool tag 17);
  Scala 2.12.11 crashes on this with `bad constant pool index: 0`. Fixed in 2.12.13;
  2.12.19 is latest stable patch. Zero binary-compatibility impact — same `_2.12` suffix.
- Fix `AwsSignUtils.scala`: `Array[Char]` has no `length()` or `charAt` — use `.length`
  and `apply(i)`; also fix off-by-one (`0 to` → `0 until`)
- `jobs-distribution`: add `<id>` required by `maven-assembly-plugin` 3.7.1 and
  `appendAssemblyId=false` to preserve existing tar artifact naming

## How Has This Been Tested?

- [x] **Compilation**: `mvn clean install -DskipTests` passes for all modules
- [x] **Unit Tests**: `mvn test -pl jobs-core`, `mvn test -pl transaction-event-processor`
- [ ] **Integration / Smoke**: Index round-trip against OpenSearch 2.19.5 via Docker

## Checklist

- [x] Self-review done
- [x] No breaking changes to `ElasticSearchUtil` public API
- [x] Pre-existing `AwsSignUtils` off-by-one bug fixed
- [x] Existing unit tests pass locally
