### PR TITLE
fix: Add IL_UNIQUE_ID to node metadata

### DIFF
--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/ObjectUpdater.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/helpers/ObjectUpdater.scala
@@ -51,7 +51,7 @@ trait ObjectUpdater {
     val prevState = obj.getString("status", "Draft")
     val identifier = obj.dbId
     val metadataUpdate = getMetadata(obj)(definitionCache, config)
-    val finalMetadata = metadataUpdate ++ Map("status" -> status, "prevState" -> prevState, "IL_FUNC_OBJECT_TYPE" -> obj.dbObjType, "IL_SYS_NODE_TYPE" -> "DATA_NODE", "objectType" -> obj.dbObjType) ++ getAuditProps()
+    val finalMetadata = metadataUpdate ++ Map("status" -> status, "prevState" -> prevState, "IL_FUNC_OBJECT_TYPE" -> obj.dbObjType, "IL_SYS_NODE_TYPE" -> "DATA_NODE", "objectType" -> obj.dbObjType, "IL_UNIQUE_ID" -> obj.dbId) ++ getAuditProps()
     
     logger.info(s"ObjectUpdater:: updateProcessingNode:: Updating node $identifier to Processing status")
     janusGraphUtil.updateNode(identifier, finalMetadata.asInstanceOf[Map[String, AnyRef]])


### PR DESCRIPTION
Include the IL_UNIQUE_ID property (set to obj.dbId) in the finalMetadata map in ObjectUpdater.scala. This ensures the unique identifier is stored on the node when updating its status (e.g., to Processing), enabling consistent identification/indexing of the node in JanusGraph.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules