### PR TITLE
feat: Enable FTB, MTF, Sequence, and Reorder question types in QuML publish pipeline

### DIFF
--- a/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/handler/QuestionHandlerFactory.scala
+++ b/publish-pipeline/publish-core/src/main/scala/org/sunbird/job/publish/handler/QuestionHandlerFactory.scala
@@ -4,6 +4,8 @@ import com.google.gson.Gson
 
 import java.util
 import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.util.Try
 
 object QuestionHandlerFactory {
     lazy private val gson = new Gson()
@@ -48,12 +50,73 @@ object QuestionHandlerFactory {
         }
     }
 
+    private class FTBHandler extends QuestionTypeHandler {
+        override def getQuestion(extData: Option[Map[String, AnyRef]]): String =
+            extData.getOrElse(Map()).getOrElse("body", "").asInstanceOf[String]
+
+        override def getAnswers(extData: Option[Map[String, AnyRef]]): List[String] = {
+            val rdJson = extData.getOrElse(Map()).getOrElse("responseDeclaration", "{}").asInstanceOf[String]
+            val rd = Try(gson.fromJson(rdJson, classOf[java.util.Map[String, AnyRef]]).asScala).getOrElse(mutable.Map.empty)
+            rd.values.toList.flatMap { responseAny =>
+                val response = responseAny.asInstanceOf[java.util.Map[String, AnyRef]].asScala
+                val mapping = Try(
+                    response.getOrElse("mapping", new util.ArrayList[util.Map[String, AnyRef]]())
+                        .asInstanceOf[util.List[util.Map[String, AnyRef]]].asScala.toList
+                ).getOrElse(List.empty)
+                mapping.map(m => m.asScala.getOrElse("value", "").asInstanceOf[String]).filter(_.nonEmpty)
+            }
+        }
+    }
+
+    private class MTFHandler extends QuestionTypeHandler {
+        override def getQuestion(extData: Option[Map[String, AnyRef]]): String =
+            extData.getOrElse(Map()).getOrElse("body", "").asInstanceOf[String]
+
+        override def getAnswers(extData: Option[Map[String, AnyRef]]): List[String] = {
+            val rdJson = extData.getOrElse(Map()).getOrElse("responseDeclaration", "{}").asInstanceOf[String]
+            val rd = Try(gson.fromJson(rdJson, classOf[java.util.Map[String, AnyRef]]).asScala).getOrElse(mutable.Map.empty)
+            val response = rd.values.headOption
+                .map(_.asInstanceOf[java.util.Map[String, AnyRef]].asScala)
+                .getOrElse(mutable.Map.empty)
+            val correctMap = Try(
+                response.getOrElse("correctResponse", new util.HashMap[String, AnyRef]())
+                    .asInstanceOf[java.util.Map[String, AnyRef]].asScala
+                    .getOrElse("value", new util.HashMap[String, AnyRef]())
+                    .asInstanceOf[java.util.Map[String, AnyRef]].asScala
+            ).getOrElse(mutable.Map.empty)
+            correctMap.map { case (k, v) => s"$k:$v" }.toList
+        }
+    }
+
+    private class SequenceHandler extends QuestionTypeHandler {
+        override def getQuestion(extData: Option[Map[String, AnyRef]]): String =
+            extData.getOrElse(Map()).getOrElse("body", "").asInstanceOf[String]
+
+        override def getAnswers(extData: Option[Map[String, AnyRef]]): List[String] = {
+            val rdJson = extData.getOrElse(Map()).getOrElse("responseDeclaration", "{}").asInstanceOf[String]
+            val rd = Try(gson.fromJson(rdJson, classOf[java.util.Map[String, AnyRef]]).asScala).getOrElse(mutable.Map.empty)
+            val response = rd.values.headOption
+                .map(_.asInstanceOf[java.util.Map[String, AnyRef]].asScala)
+                .getOrElse(mutable.Map.empty)
+            Try(
+                response.getOrElse("correctResponse", new util.HashMap[String, AnyRef]())
+                    .asInstanceOf[java.util.Map[String, AnyRef]].asScala
+                    .getOrElse("value", new util.ArrayList[AnyRef]())
+                    .asInstanceOf[util.List[AnyRef]].asScala.toList
+                    .map(_.asInstanceOf[String])
+            ).getOrElse(List.empty)
+        }
+    }
+
 
     def apply(questionType: Option[String]): Option[QuestionTypeHandler] = questionType match {
-        case Some("Multiple Choice Question") => Some(new MCQHandler)
-        case Some("Subjective Question") => Some(new SubjectiveHandler)
-        case Some("FTB Question") => None
-        case _ => None
+        case Some("Multiple Choice Question")     => Some(new MCQHandler)
+        case Some("Subjective Question")          => Some(new SubjectiveHandler)
+        case Some("FTB Question")                 => Some(new FTBHandler)
+        case Some("Match The Following Question") => Some(new MTFHandler)
+        case Some("Sequence Question")            => Some(new SequenceHandler)
+        case Some("Reorder Question")             => Some(new SequenceHandler)
+        case _                                    => None
     }
 
 }

--- a/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/handler/QuestionHandlerFactorySpec.scala
+++ b/publish-pipeline/publish-core/src/test/scala/org/sunbird/job/publish/handler/QuestionHandlerFactorySpec.scala
@@ -1,0 +1,254 @@
+package org.sunbird.job.publish.handler
+
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+
+class QuestionHandlerFactorySpec extends FlatSpec with BeforeAndAfterAll with Matchers {
+
+  // ─── FTBHandler — happy paths ─────────────────────────────────────────────────
+
+  "FTBHandler" should "return body as the question" in {
+    val handler = QuestionHandlerFactory(Some("FTB Question"))
+    handler shouldBe defined
+    handler.get.getQuestion(Some(Map("body" -> "<p>Fill in the blank</p>"))) shouldBe "<p>Fill in the blank</p>"
+  }
+
+  it should "extract all mapping values across multiple blanks" in {
+    val rd =
+      """{
+        |  "response1": {
+        |    "mapping": [
+        |      {"response": "response1", "value": "sun"},
+        |      {"response": "response1", "value": "solar"}
+        |    ]
+        |  },
+        |  "response2": {
+        |    "mapping": [
+        |      {"response": "response2", "value": "moon"}
+        |    ]
+        |  }
+        |}""".stripMargin
+    val handler = QuestionHandlerFactory(Some("FTB Question")).get
+    val answers = handler.getAnswers(Some(Map("responseDeclaration" -> rd)))
+    answers should contain allOf ("sun", "solar", "moon")
+    answers should have size 3
+  }
+
+  it should "support multiple accepted values per blank (i18n / alternate answers)" in {
+    val rd =
+      """{
+        |  "response1": {
+        |    "mapping": [
+        |      {"response": "response1", "value": "colour"},
+        |      {"response": "response1", "value": "color"}
+        |    ]
+        |  }
+        |}""".stripMargin
+    val handler = QuestionHandlerFactory(Some("FTB Question")).get
+    val answers = handler.getAnswers(Some(Map("responseDeclaration" -> rd)))
+    answers should contain allOf ("colour", "color")
+    answers should have size 2
+  }
+
+  // ─── FTBHandler — edge cases ──────────────────────────────────────────────────
+
+  it should "return empty list when mapping array is empty" in {
+    val rd = """{"response1": {"mapping": []}}"""
+    val handler = QuestionHandlerFactory(Some("FTB Question")).get
+    handler.getAnswers(Some(Map("responseDeclaration" -> rd))) shouldBe empty
+  }
+
+  it should "return empty list when responseDeclaration is an empty JSON object" in {
+    val handler = QuestionHandlerFactory(Some("FTB Question")).get
+    handler.getAnswers(Some(Map("responseDeclaration" -> "{}"))) shouldBe empty
+  }
+
+  it should "return empty list when extData is None" in {
+    val handler = QuestionHandlerFactory(Some("FTB Question")).get
+    handler.getAnswers(None) shouldBe empty
+  }
+
+  it should "return empty list when responseDeclaration JSON is malformed" in {
+    val handler = QuestionHandlerFactory(Some("FTB Question")).get
+    handler.getAnswers(Some(Map("responseDeclaration" -> "{not valid json"))) shouldBe empty
+  }
+
+  it should "skip mapping entries that have no value key" in {
+    val rd = """{"response1": {"mapping": [{"response": "response1"}]}}"""
+    val handler = QuestionHandlerFactory(Some("FTB Question")).get
+    handler.getAnswers(Some(Map("responseDeclaration" -> rd))) shouldBe empty
+  }
+
+  it should "return empty string for question when extData is None" in {
+    val handler = QuestionHandlerFactory(Some("FTB Question")).get
+    handler.getQuestion(None) shouldBe ""
+  }
+
+  it should "return empty string for question when body key is absent" in {
+    val handler = QuestionHandlerFactory(Some("FTB Question")).get
+    handler.getQuestion(Some(Map())) shouldBe ""
+  }
+
+  // ─── MTFHandler — happy paths ─────────────────────────────────────────────────
+
+  "MTFHandler" should "extract lhs:rhs pairs from correctResponse.value map" in {
+    val rd =
+      """{
+        |  "response1": {
+        |    "correctResponse": {
+        |      "value": {
+        |        "0": "2",
+        |        "1": "3",
+        |        "2": "1"
+        |      }
+        |    }
+        |  }
+        |}""".stripMargin
+    val handler = QuestionHandlerFactory(Some("Match The Following Question")).get
+    val answers = handler.getAnswers(Some(Map("responseDeclaration" -> rd)))
+    answers should contain allOf ("0:2", "1:3", "2:1")
+    answers should have size 3
+  }
+
+  it should "return body as the question" in {
+    val handler = QuestionHandlerFactory(Some("Match The Following Question")).get
+    handler.getQuestion(Some(Map("body" -> "<p>Match the following</p>"))) shouldBe "<p>Match the following</p>"
+  }
+
+  // ─── MTFHandler — edge cases ──────────────────────────────────────────────────
+
+  it should "return empty list when responseDeclaration is an empty JSON object" in {
+    val handler = QuestionHandlerFactory(Some("Match The Following Question")).get
+    handler.getAnswers(Some(Map("responseDeclaration" -> "{}"))) shouldBe empty
+  }
+
+  it should "return empty list when extData is None" in {
+    val handler = QuestionHandlerFactory(Some("Match The Following Question")).get
+    handler.getAnswers(None) shouldBe empty
+  }
+
+  it should "return empty list when responseDeclaration JSON is malformed" in {
+    val handler = QuestionHandlerFactory(Some("Match The Following Question")).get
+    handler.getAnswers(Some(Map("responseDeclaration" -> "{not valid json"))) shouldBe empty
+  }
+
+  it should "return empty string for question when extData is None" in {
+    val handler = QuestionHandlerFactory(Some("Match The Following Question")).get
+    handler.getQuestion(None) shouldBe ""
+  }
+
+  // ─── SequenceHandler (Sequence Question) — happy paths ───────────────────────
+
+  "SequenceHandler for Sequence Question" should "return values in the declared correct order" in {
+    val rd =
+      """{
+        |  "response1": {
+        |    "correctResponse": {
+        |      "value": ["3", "1", "4", "2"]
+        |    }
+        |  }
+        |}""".stripMargin
+    val handler = QuestionHandlerFactory(Some("Sequence Question")).get
+    handler.getAnswers(Some(Map("responseDeclaration" -> rd))) shouldBe List("3", "1", "4", "2")
+  }
+
+  it should "return body as the question" in {
+    val handler = QuestionHandlerFactory(Some("Sequence Question")).get
+    handler.getQuestion(Some(Map("body" -> "<p>Arrange in order</p>"))) shouldBe "<p>Arrange in order</p>"
+  }
+
+  it should "preserve order for a single-element sequence" in {
+    val rd = """{"response1": {"correctResponse": {"value": ["1"]}}}"""
+    val handler = QuestionHandlerFactory(Some("Sequence Question")).get
+    handler.getAnswers(Some(Map("responseDeclaration" -> rd))) shouldBe List("1")
+  }
+
+  // ─── SequenceHandler (Sequence Question) — edge cases ────────────────────────
+
+  it should "return empty list when responseDeclaration is an empty JSON object" in {
+    val handler = QuestionHandlerFactory(Some("Sequence Question")).get
+    handler.getAnswers(Some(Map("responseDeclaration" -> "{}"))) shouldBe empty
+  }
+
+  it should "return empty list when extData is None" in {
+    val handler = QuestionHandlerFactory(Some("Sequence Question")).get
+    handler.getAnswers(None) shouldBe empty
+  }
+
+  it should "return empty list when responseDeclaration JSON is malformed" in {
+    val handler = QuestionHandlerFactory(Some("Sequence Question")).get
+    handler.getAnswers(Some(Map("responseDeclaration" -> "{not valid json"))) shouldBe empty
+  }
+
+  it should "return empty string for question when extData is None" in {
+    val handler = QuestionHandlerFactory(Some("Sequence Question")).get
+    handler.getQuestion(None) shouldBe ""
+  }
+
+  // ─── SequenceHandler (Reorder Question) — happy paths ────────────────────────
+
+  "SequenceHandler for Reorder Question" should "return values in the declared correct order" in {
+    val rd =
+      """{
+        |  "response1": {
+        |    "correctResponse": {
+        |      "value": ["2", "4", "1", "3"]
+        |    }
+        |  }
+        |}""".stripMargin
+    val handler = QuestionHandlerFactory(Some("Reorder Question")).get
+    handler.getAnswers(Some(Map("responseDeclaration" -> rd))) shouldBe List("2", "4", "1", "3")
+  }
+
+  // ─── SequenceHandler (Reorder Question) — edge cases ─────────────────────────
+
+  it should "return empty list when responseDeclaration is an empty JSON object" in {
+    val handler = QuestionHandlerFactory(Some("Reorder Question")).get
+    handler.getAnswers(Some(Map("responseDeclaration" -> "{}"))) shouldBe empty
+  }
+
+  it should "return empty list when extData is None" in {
+    val handler = QuestionHandlerFactory(Some("Reorder Question")).get
+    handler.getAnswers(None) shouldBe empty
+  }
+
+  it should "return empty list when responseDeclaration JSON is malformed" in {
+    val handler = QuestionHandlerFactory(Some("Reorder Question")).get
+    handler.getAnswers(Some(Map("responseDeclaration" -> "{not valid json"))) shouldBe empty
+  }
+
+  // ─── apply() dispatch ─────────────────────────────────────────────────────────
+
+  "QuestionHandlerFactory.apply" should "return Some handler for FTB Question" in {
+    QuestionHandlerFactory(Some("FTB Question")) shouldBe defined
+  }
+
+  it should "return Some handler for Match The Following Question" in {
+    QuestionHandlerFactory(Some("Match The Following Question")) shouldBe defined
+  }
+
+  it should "return Some handler for Sequence Question" in {
+    QuestionHandlerFactory(Some("Sequence Question")) shouldBe defined
+  }
+
+  it should "return Some handler for Reorder Question" in {
+    QuestionHandlerFactory(Some("Reorder Question")) shouldBe defined
+  }
+
+  it should "return None for an unknown question type" in {
+    QuestionHandlerFactory(Some("Unknown Type")) shouldBe None
+  }
+
+  it should "return None for None input" in {
+    QuestionHandlerFactory(None) shouldBe None
+  }
+
+  // ─── Regression: pre-existing handlers still dispatch correctly ───────────────
+
+  it should "return Some handler for Multiple Choice Question (regression)" in {
+    QuestionHandlerFactory(Some("Multiple Choice Question")) shouldBe defined
+  }
+
+  it should "return Some handler for Subjective Question (regression)" in {
+    QuestionHandlerFactory(Some("Subjective Question")) shouldBe defined
+  }
+}


### PR DESCRIPTION
- Added FTBHandler, MTFHandler, and SequenceHandler inner classes to QuestionHandlerFactory.scala to extract correct answers for the four new QuML question types (Fill in the Blank, Match the Following, Sequence, Reorder).
- Extended the apply() dispatch to route all four new types; Reorder reuses SequenceHandler (identical scoring path).
- Added scala.util.Try wrapping throughout so malformed or missing responseDeclaration JSON always degrades gracefully to an empty list instead of throwing.
- Added QuestionHandlerFactorySpec.scala with 35 unit tests covering happy paths, multi-blank / i18n alternate answers, empty inputs, malformed JSON, None extData, and regression guards for the pre-existing MCQ and Subjective handlers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added support for Fill The Blank questions
- Added support for Match The Following questions
- Added support for Sequence questions
- Reorder questions now handled with sequence logic

**Tests**
- Added comprehensive test specifications for question type handling and answer extraction across all supported question types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->