### PR TITLE
fix: handle large nodeGraphId (>Int.MaxValue)

### DIFF
--- a/transaction-event-processor/src/main/scala/org/sunbird/job/transaction/compositesearch/helpers/CompositeSearchIndexerHelper.scala
+++ b/transaction-event-processor/src/main/scala/org/sunbird/job/transaction/compositesearch/helpers/CompositeSearchIndexerHelper.scala
@@ -128,7 +128,7 @@ trait CompositeSearchIndexerHelper {
     )
     indexDocument.put(
       "node_id",
-      message.getOrElse("nodeGraphId", 0).asInstanceOf[Integer]
+      Long.box(message.getOrElse("nodeGraphId", 0).asInstanceOf[Number].longValue())
     )
     indexDocument.put(
       "identifier",

--- a/transaction-event-processor/src/main/scala/org/sunbird/job/transaction/compositesearch/helpers/CompositeSearchIndexerHelper.scala
+++ b/transaction-event-processor/src/main/scala/org/sunbird/job/transaction/compositesearch/helpers/CompositeSearchIndexerHelper.scala
@@ -285,7 +285,7 @@ trait CompositeSearchIndexerHelper {
     messageMap.put("objectType", objectType)
     messageMap.put("graphId", graphId)
     messageMap.put("nodeType", nodeType)
-    messageMap.put("nodeGraphId", Integer.valueOf(event.readOrDefault("nodeGraphId", 0)))
+    messageMap.put("nodeGraphId", Long.box(event.readOrDefault[AnyRef]("nodeGraphId", Int.box(0)).asInstanceOf[Number].longValue()))
     messageMap.put("transactionData", Map("properties" -> properties))
 
     CompositeIndexer(graphId, objectType, identifier, event.readOrDefault("mid", ""), messageMap, config)

--- a/transaction-event-processor/src/test/scala/org/sunbird/job/spec/SearchIndexerTaskTestSpec.scala
+++ b/transaction-event-processor/src/test/scala/org/sunbird/job/spec/SearchIndexerTaskTestSpec.scala
@@ -153,6 +153,23 @@ class SearchIndexerTaskTestSpec extends BaseTestSpec {
     )
   }
 
+  it should "index a nodeGraphId larger than Int.MaxValue without losing precision" in {
+    val definition =
+      defCache.getDefinition("Collection", "1.0", jobConfig.definitionBasePath)
+    val compositeFunc = new CompositeSearchIndexerFunction(jobConfig)
+    val bigId: Long = 2170888320L // > Int.MaxValue (2147483647)
+    val message = getEvent(EventFixture.DATA_NODE_CREATE, 509674).getMap().asScala.toMap +
+      ("nodeGraphId" -> Long.box(bigId))
+    val indexDocument: Map[String, AnyRef] = compositeFunc.getIndexDocument(
+      message,
+      false,
+      definition,
+      jobConfig.nestedFields.asScala.toList,
+      jobConfig.ignoredFields
+    )(mockElasticUtil)
+    indexDocument.getOrElse("node_id", 0).asInstanceOf[Long] should be(bigId)
+  }
+
   it should "return the indexable document with the added relation for the provided object" in {
     val definition =
       defCache.getDefinition("Collection", "1.0", jobConfig.definitionBasePath)


### PR DESCRIPTION
## Summary

Fixes the production failure in the `transaction-event-processor` job that caused Flink job restart loops.

### `ClassCastException: Long cannot be cast to Integer` — composite search indexer

The graph node-id sequence (`nodeGraphId`) crossed the 32-bit `Integer.MAX_VALUE` ceiling (2,147,483,647). Jackson deserializes integral values above that boundary as `java.lang.Long`. Two sites then hard-cast/unboxed to `Int`, throwing `ClassCastException` and crashing the job into a restart loop for any node with id > 2.1B:

- `CompositeSearchIndexerHelper.getIndexDocument` (line 131) — `asInstanceOf[Integer]`
- `CompositeSearchIndexerHelper.buildCompositeIndexerFromGraph` (line 288) — `Integer.valueOf(readOrDefault(..., 0))` → `unboxToInt`

Both now read via `Number.longValue()` and box as `java.lang.Long`, matching the existing `long` `node_id` mapping in OpenSearch. No truncation, no crash, works for both small (`Integer`) and large (`Long`) ids.

## Commits

- `f494f87` — handle nodeGraphId > Int.MaxValue in `getIndexDocument`
- `772b0af` — handle nodeGraphId > Int.MaxValue in `buildCompositeIndexerFromGraph`

## Testing

- Added a unit test asserting `node_id` survives a `nodeGraphId` > `Int.MaxValue` without precision loss (`SearchIndexerTaskTestSpec`).
- `transaction-event-processor` and `publish-core` main sources compile clean.