### PR TITLE
build: upgrade Flink from 1.18.1 to 1.20.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,15 +148,15 @@ If no profile is specified, the default build targets Azure.
 
 > Use this option to run the job the same way it runs in production.
 
-1. Download and extract Flink 1.18.1:
+1. Download and extract Flink 1.20.5:
    ```shell
-   wget https://dlcdn.apache.org/flink/flink-1.18.1/flink-1.18.1-bin-scala_2.12.tgz
-   tar xzf flink-1.18.1-bin-scala_2.12.tgz
+   wget https://dlcdn.apache.org/flink/flink-1.20.5/flink-1.20.5-bin-scala_2.12.tgz
+   tar xzf flink-1.20.5-bin-scala_2.12.tgz
    ```
 
 2. Start the Flink cluster:
    ```shell
-   cd flink-1.18.1
+   cd flink-1.20.5
    ./bin/start-cluster.sh
    ```
    Verify: open http://localhost:8081 — you should see the Flink dashboard with 1 TaskManager.
@@ -194,16 +194,16 @@ If no profile is specified, the default build targets Azure.
    ```xml
    <dependency>
      <groupId>org.apache.flink</groupId>
-     <artifactId>flink-clients_${scala.version}</artifactId>
+     <artifactId>flink-clients</artifactId>
      <version>${flink.version}</version>
    </dependency>
    ```
 
-   Comment out the `provided` scope on `flink-streaming-scala`:
+   Comment out the `provided` scope on `flink-streaming-java`:
    ```xml
    <dependency>
      <groupId>org.apache.flink</groupId>
-     <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+     <artifactId>flink-streaming-java</artifactId>
      <version>${flink.version}</version>
      <!-- <scope>provided</scope> -->
    </dependency>

--- a/asset-enrichment/pom.xml
+++ b/asset-enrichment/pom.xml
@@ -29,7 +29,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -142,6 +142,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/asset-enrichment/src/main/scala/org/sunbird/job/assetenricment/task/AssetEnrichmentConfig.scala
+++ b/asset-enrichment/src/main/scala/org/sunbird/job/assetenricment/task/AssetEnrichmentConfig.scala
@@ -3,7 +3,7 @@ package org.sunbird.job.assetenricment.task
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.BaseJobConfig
 import org.sunbird.job.assetenricment.domain.Event
 
@@ -46,9 +46,9 @@ class AssetEnrichmentConfig(override val config: Config) extends BaseJobConfig(c
 
 
   // Tags
-  val imageEnrichmentDataOutTag: OutputTag[Event] = OutputTag[Event]("image-enrichment-data")
-  val videoEnrichmentDataOutTag: OutputTag[Event] = OutputTag[Event]("video-enrichment-data")
-  val generateVideoStreamingOutTag: OutputTag[String] = OutputTag[String]("video-streaming-generator-request")
+  val imageEnrichmentDataOutTag: OutputTag[Event] = new OutputTag[Event]("image-enrichment-data", eventTypeInfo)
+  val videoEnrichmentDataOutTag: OutputTag[Event] = new OutputTag[Event]("video-enrichment-data", eventTypeInfo)
+  val generateVideoStreamingOutTag: OutputTag[String] = new OutputTag[String]("video-streaming-generator-request", TypeInformation.of(classOf[String]))
 
   // Asset Variables
   val contentUploadContextDriven: Boolean = if (config.hasPath("content.upload.context.driven")) config.getBoolean("content.upload.context.driven") else true

--- a/asset-enrichment/src/main/scala/org/sunbird/job/assetenricment/task/AssetEnrichmentStreamTask.scala
+++ b/asset-enrichment/src/main/scala/org/sunbird/job/assetenricment/task/AssetEnrichmentStreamTask.scala
@@ -5,7 +5,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.assetenricment.domain.Event
 import org.sunbird.job.assetenricment.functions.{AssetEnrichmentEventRouter, ImageEnrichmentFunction, VideoEnrichmentFunction}
 import org.sunbird.job.connector.FlinkKafkaConnector

--- a/cassandra-data-migration/pom.xml
+++ b/cassandra-data-migration/pom.xml
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -110,6 +110,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/cassandra-data-migration/src/main/scala/org/sunbird/job/task/CassandraDataMigrationStreamTask.scala
+++ b/cassandra-data-migration/src/main/scala/org/sunbird/job/task/CassandraDataMigrationStreamTask.scala
@@ -5,7 +5,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.slf4j.LoggerFactory
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.migration.domain.Event

--- a/content-embedding-job/content-embedding-core/pom.xml
+++ b/content-embedding-job/content-embedding-core/pom.xml
@@ -36,7 +36,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -128,6 +128,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>

--- a/content-embedding-job/content-embedding-core/src/main/resources/log4j.properties
+++ b/content-embedding-job/content-embedding-core/src/main/resources/log4j.properties
@@ -1,6 +1,6 @@
 # log4j.appender.file=org.apache.log4j.FileAppender
 log4j.appender.file=org.apache.log4j.RollingFileAppender
-log4j.appender.file.file=-content-publish.log
+log4j.appender.file.file=-content-embedding.log
 log4j.appender.file.append=true
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.MaxFileSize=256KB

--- a/content-embedding-job/content-embedding-core/src/main/scala/org/sunbird/job/contentembedding/task/ContentEmbeddingConfig.scala
+++ b/content-embedding-job/content-embedding-core/src/main/scala/org/sunbird/job/contentembedding/task/ContentEmbeddingConfig.scala
@@ -3,7 +3,7 @@ package org.sunbird.job.contentembedding.task
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.BaseJobConfig
 import org.sunbird.job.contentembedding.domain.{ChunkedEvent, ChunkingConfig, EmbeddedEvent, EmbeddingOutput, EmbeddingServiceConfig, EnrichedMetadataEvent, QuantizationConfig}
 import scala.collection.JavaConverters._
@@ -92,12 +92,12 @@ class ContentEmbeddingConfig(override val config: Config) extends BaseJobConfig(
     TypeExtractor.getForClass(classOf[EmbeddingOutput])
 
   // Output Tags — pipeline routing via side outputs (Flink codebase pattern)
-  val errorOutTag: OutputTag[String]                     = OutputTag[String]("embedding-error")
-  val successOutTag: OutputTag[String]                   = OutputTag[String]("embedding-success")
-  val enrichedOutTag: OutputTag[EnrichedMetadataEvent]   = OutputTag[EnrichedMetadataEvent]("enriched-metadata")
-  val chunkedOutTag: OutputTag[ChunkedEvent]             = OutputTag[ChunkedEvent]("chunked-event")
-  val embeddedOutTag: OutputTag[EmbeddedEvent]           = OutputTag[EmbeddedEvent]("embedded-event")
-  val quantizedOutTag: OutputTag[EmbeddingOutput]        = OutputTag[EmbeddingOutput]("quantized-event")
+  val errorOutTag: OutputTag[String]                     = new OutputTag[String]("embedding-error", stringTypeInfo)
+  val successOutTag: OutputTag[String]                   = new OutputTag[String]("embedding-success", stringTypeInfo)
+  val enrichedOutTag: OutputTag[EnrichedMetadataEvent]   = new OutputTag[EnrichedMetadataEvent]("enriched-metadata", enrichedMetadataEventTypeInfo)
+  val chunkedOutTag: OutputTag[ChunkedEvent]             = new OutputTag[ChunkedEvent]("chunked-event", chunkedEventTypeInfo)
+  val embeddedOutTag: OutputTag[EmbeddedEvent]           = new OutputTag[EmbeddedEvent]("embedded-event", embeddedEventTypeInfo)
+  val quantizedOutTag: OutputTag[EmbeddingOutput]        = new OutputTag[EmbeddingOutput]("quantized-event", embeddingOutputTypeInfo)
 
   def embeddingServiceConfig: EmbeddingServiceConfig = embeddingService match {
     case "e5" => EmbeddingServiceConfig(

--- a/content-embedding-job/content-embedding-core/src/main/scala/org/sunbird/job/contentembedding/task/ContentEmbeddingStreamTask.scala
+++ b/content-embedding-job/content-embedding-core/src/main/scala/org/sunbird/job/contentembedding/task/ContentEmbeddingStreamTask.scala
@@ -114,14 +114,19 @@ class ContentEmbeddingStreamTask(config: ContentEmbeddingConfig, kafkaConnector:
     // Success IDs → output topic
     sinkStream.getSideOutput(config.successOutTag)
       .sinkTo(kafkaConnector.kafkaStringSink(config.kafkaOutputTopic))
+      .name("opensearch-sink-output-sink").uid("opensearch-sink-output-sink")
 
     // Error DLQ — collect from all stages
-    val errorSink = kafkaConnector.kafkaStringSink(config.kafkaErrorTopic)
-    extractStream.getSideOutput(config.errorOutTag).sinkTo(errorSink)
-    chunkingStream.getSideOutput(config.errorOutTag).sinkTo(errorSink)
-    embeddingStream.getSideOutput(config.errorOutTag).sinkTo(errorSink)
-    quantizationStream.getSideOutput(config.errorOutTag).sinkTo(errorSink)
-    sinkStream.getSideOutput(config.errorOutTag).sinkTo(errorSink)
+    extractStream.getSideOutput(config.errorOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
+      .name("extract-error-sink").uid("extract-error-sink")
+    chunkingStream.getSideOutput(config.errorOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
+      .name("chunking-error-sink").uid("chunking-error-sink")
+    embeddingStream.getSideOutput(config.errorOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
+      .name("embedding-error-sink").uid("embedding-error-sink")
+    quantizationStream.getSideOutput(config.errorOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
+      .name("quantization-error-sink").uid("quantization-error-sink")
+    sinkStream.getSideOutput(config.errorOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
+      .name("opensearch-sink-error-sink").uid("opensearch-sink-error-sink")
 
     logger.info("Content embedding pipeline built")
   }

--- a/content-embedding-job/content-embedding-core/src/main/scala/org/sunbird/job/contentembedding/task/ContentEmbeddingStreamTask.scala
+++ b/content-embedding-job/content-embedding-core/src/main/scala/org/sunbird/job/contentembedding/task/ContentEmbeddingStreamTask.scala
@@ -114,19 +114,14 @@ class ContentEmbeddingStreamTask(config: ContentEmbeddingConfig, kafkaConnector:
     // Success IDs → output topic
     sinkStream.getSideOutput(config.successOutTag)
       .sinkTo(kafkaConnector.kafkaStringSink(config.kafkaOutputTopic))
-      .name("opensearch-sink-output-sink").uid("opensearch-sink-output-sink")
 
     // Error DLQ — collect from all stages
-    extractStream.getSideOutput(config.errorOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
-      .name("extract-error-sink").uid("extract-error-sink")
-    chunkingStream.getSideOutput(config.errorOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
-      .name("chunking-error-sink").uid("chunking-error-sink")
-    embeddingStream.getSideOutput(config.errorOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
-      .name("embedding-error-sink").uid("embedding-error-sink")
-    quantizationStream.getSideOutput(config.errorOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
-      .name("quantization-error-sink").uid("quantization-error-sink")
-    sinkStream.getSideOutput(config.errorOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
-      .name("opensearch-sink-error-sink").uid("opensearch-sink-error-sink")
+    val errorSink = kafkaConnector.kafkaStringSink(config.kafkaErrorTopic)
+    extractStream.getSideOutput(config.errorOutTag).sinkTo(errorSink)
+    chunkingStream.getSideOutput(config.errorOutTag).sinkTo(errorSink)
+    embeddingStream.getSideOutput(config.errorOutTag).sinkTo(errorSink)
+    quantizationStream.getSideOutput(config.errorOutTag).sinkTo(errorSink)
+    sinkStream.getSideOutput(config.errorOutTag).sinkTo(errorSink)
 
     logger.info("Content embedding pipeline built")
   }

--- a/content-embedding-job/content-embedding-core/src/main/scala/org/sunbird/job/contentembedding/task/ContentEmbeddingStreamTask.scala
+++ b/content-embedding-job/content-embedding-core/src/main/scala/org/sunbird/job/contentembedding/task/ContentEmbeddingStreamTask.scala
@@ -5,7 +5,8 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.slf4j.LoggerFactory
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.contentembedding.domain.{ChunkedEvent, EmbeddedEvent, EmbeddingOutput, EnrichedMetadataEvent}

--- a/dialcode-context-updater/pom.xml
+++ b/dialcode-context-updater/pom.xml
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -110,6 +110,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/dialcode-context-updater/src/main/scala/org/sunbird/job/dialcodecontextupdater/task/DialcodeContextUpdaterConfig.scala
+++ b/dialcode-context-updater/src/main/scala/org/sunbird/job/dialcodecontextupdater/task/DialcodeContextUpdaterConfig.scala
@@ -3,7 +3,7 @@ package org.sunbird.job.dialcodecontextupdater.task
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.BaseJobConfig
 import org.sunbird.job.dialcodecontextupdater.domain.Event
 
@@ -37,8 +37,8 @@ class DialcodeContextUpdaterConfig(override val config: Config) extends BaseJobC
   val dialcodeContextUpdaterEventProducer = "dialcode-context-updater-producer"
 
   // Tags
-  val dialcodeContextUpdaterOutputTag: OutputTag[Event] = OutputTag[Event]("dialcode-context-updater")
-  val failedEventOutTag: OutputTag[String] = OutputTag[String]("dialcode-context-updater-failed-event")
+  val dialcodeContextUpdaterOutputTag: OutputTag[Event] = new OutputTag[Event]("dialcode-context-updater", dialcodeContextUpdaterTypeInfo)
+  val failedEventOutTag: OutputTag[String] = new OutputTag[String]("dialcode-context-updater-failed-event", stringTypeInfo)
 
   val configVersion = "1.0"
 

--- a/dialcode-context-updater/src/main/scala/org/sunbird/job/dialcodecontextupdater/task/DialcodeContextUpdaterStreamTask.scala
+++ b/dialcode-context-updater/src/main/scala/org/sunbird/job/dialcodecontextupdater/task/DialcodeContextUpdaterStreamTask.scala
@@ -5,7 +5,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.dialcodecontextupdater.domain.Event
 import org.sunbird.job.dialcodecontextupdater.functions.DialcodeContextUpdaterFunction

--- a/jobs-core/pom.xml
+++ b/jobs-core/pom.xml
@@ -83,23 +83,29 @@
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-core</artifactId>
             <version>1.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-cql</artifactId>
             <version>1.0.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-lang</groupId>
+                    <artifactId>commons-lang</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-inmemory</artifactId>
             <version>1.0.0</version>
             <scope>test</scope>
-        </dependency>
-        <!-- JanusGraph's KCVSConfiguration.close() references this legacy class directly at runtime -->
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
         </dependency>
 
         <!-- Netty dependencies required by JanusGraph CQL backend -->

--- a/jobs-core/pom.xml
+++ b/jobs-core/pom.xml
@@ -20,13 +20,13 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-kafka</artifactId>
-            <version>3.2.0-1.18</version>
+            <version>3.4.0-1.20</version>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
@@ -83,29 +83,23 @@
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-core</artifactId>
             <version>1.0.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-lang</groupId>
-                    <artifactId>commons-lang</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-cql</artifactId>
             <version>1.0.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-lang</groupId>
-                    <artifactId>commons-lang</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-inmemory</artifactId>
             <version>1.0.0</version>
             <scope>test</scope>
+        </dependency>
+        <!-- JanusGraph's KCVSConfiguration.close() references this legacy class directly at runtime -->
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
         </dependency>
 
         <!-- Netty dependencies required by JanusGraph CQL backend -->
@@ -263,7 +257,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.14.0</version>
+            <version>2.15.1</version>
         </dependency>
         <dependency>
             <groupId>at.yawk.lz4</groupId>

--- a/jobs-core/src/main/scala/org/sunbird/job/BaseProcessFunction.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/BaseProcessFunction.scala
@@ -3,7 +3,7 @@ package org.sunbird.job
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.metrics.Gauge
 import org.apache.flink.streaming.api.functions.{KeyedProcessFunction, ProcessFunction}
-import org.apache.flink.streaming.api.scala.function.ProcessWindowFunction
+import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction
 import org.apache.flink.streaming.api.windowing.windows.{GlobalWindow, TimeWindow}
 import org.apache.flink.util.Collector
 
@@ -69,10 +69,10 @@ abstract class WindowBaseProcessFunction[I, O, K](config: BaseJobConfig) extends
 
   def process(key: K,
               context: ProcessWindowFunction[I, O, K, GlobalWindow]#Context,
-              elements: Iterable[I],
+              elements: java.lang.Iterable[I],
               metrics: Metrics): Unit
 
-  override def process(key: K, context: Context, elements: Iterable[I], out: Collector[O]): Unit = {
+  override def process(key: K, context: ProcessWindowFunction[I, O, K, GlobalWindow]#Context, elements: java.lang.Iterable[I], out: Collector[O]): Unit = {
     process(key, context, elements, metrics)
   }
 }
@@ -93,10 +93,10 @@ abstract class TimeWindowBaseProcessFunction[I, O, K](config: BaseJobConfig) ext
 
   def process(key: K,
               context: ProcessWindowFunction[I, O, K, TimeWindow]#Context,
-              elements: Iterable[I],
+              elements: java.lang.Iterable[I],
               metrics: Metrics): Unit
 
-  override def process(key: K, context: Context, elements: Iterable[I], out: Collector[O]): Unit = {
+  override def process(key: K, context: ProcessWindowFunction[I, O, K, TimeWindow]#Context, elements: java.lang.Iterable[I], out: Collector[O]): Unit = {
     process(key, context, elements, metrics)
   }
 }

--- a/jobs-core/src/main/scala/org/sunbird/job/util/FlinkUtil.scala
+++ b/jobs-core/src/main/scala/org/sunbird/job/util/FlinkUtil.scala
@@ -1,17 +1,24 @@
 package org.sunbird.job.util
 
-import org.apache.flink.api.common.restartstrategy.RestartStrategies
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.configuration.RestartStrategyOptions
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackend
 import org.apache.flink.runtime.state.storage.FileSystemCheckpointStorage
 import org.apache.flink.streaming.api.environment.CheckpointConfig
-import org.apache.flink.streaming.api.environment.CheckpointConfig.ExternalizedCheckpointCleanup
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.BaseJobConfig
+
+import java.time.Duration
 
 object FlinkUtil {
 
   def getExecutionContext(config: BaseJobConfig): StreamExecutionEnvironment = {
-    val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment
+    val flinkConfig = new Configuration()
+    flinkConfig.set(RestartStrategyOptions.RESTART_STRATEGY, "fixed-delay")
+    flinkConfig.set(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_ATTEMPTS, Integer.valueOf(config.restartAttempts))
+    flinkConfig.set(RestartStrategyOptions.RESTART_STRATEGY_FIXED_DELAY_DELAY, Duration.ofMillis(config.delayBetweenAttempts))
+
+    val env: StreamExecutionEnvironment = StreamExecutionEnvironment.getExecutionEnvironment(flinkConfig)
     env.getConfig.setUseSnapshotCompression(config.enableCompressedCheckpointing)
     env.enableCheckpointing(config.checkpointingInterval)
     env.getCheckpointConfig.setCheckpointTimeout(config.checkpointingTimeout)
@@ -28,12 +35,11 @@ object FlinkUtil {
         checkpointConfig.setCheckpointStorage(
           new FileSystemCheckpointStorage(s"${config.checkpointingBaseUrl.getOrElse("")}/${config.jobName}")
         )
-        checkpointConfig.enableExternalizedCheckpoints(ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION)
+        checkpointConfig.enableExternalizedCheckpoints(CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION)
         checkpointConfig.setMinPauseBetweenCheckpoints(config.checkpointingPauseSeconds)
       case _ => // Do nothing
     }
 
-    env.setRestartStrategy(RestartStrategies.fixedDelayRestart(config.restartAttempts, config.delayBetweenAttempts))
     env
   }
 }

--- a/jobs-core/src/test/scala/org/sunbird/spec/BaseProcessFunctionTestSpec.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/BaseProcessFunctionTestSpec.scala
@@ -5,8 +5,9 @@ import com.typesafe.config.{Config, ConfigFactory}
 import net.manub.embeddedkafka.EmbeddedKafka._
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
+import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
-import org.apache.flink.streaming.api.scala._
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.scalatest.Matchers
@@ -28,6 +29,7 @@ class BaseProcessFunctionTestSpec extends BaseSpec with Matchers {
   val gson = new Gson()
 
   val kafkaConnector = new FlinkKafkaConnector(bsConfig)
+  implicit val stringTypeInfo: TypeInformation[String] = TypeInformation.of(classOf[String])
 
   val EVENT_WITH_MESSAGE_ID: String =
     """

--- a/jobs-core/src/test/scala/org/sunbird/spec/BaseProcessTestConfig.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/BaseProcessTestConfig.scala
@@ -4,7 +4,7 @@ import java.util
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.BaseJobConfig
 import org.sunbird.job.domain.reader.JobRequest
 
@@ -13,9 +13,9 @@ class BaseProcessTestConfig(override val config: Config) extends BaseJobConfig(c
   implicit val mapTypeInfo: TypeInformation[util.Map[String, AnyRef]] = TypeExtractor.getForClass(classOf[util.Map[String, AnyRef]])
   implicit val jobReqTypeInfo: TypeInformation[TestJobRequest] = TypeExtractor.getForClass(classOf[TestJobRequest])
 
-  val mapOutputTag: OutputTag[util.Map[String, AnyRef]] = OutputTag[util.Map[String, AnyRef]]("test-map-stream-tag")
-  val stringOutputTag: OutputTag[String] = OutputTag[String]("test-string-stream-tag")
-  val jobRequestOutputTag: OutputTag[TestJobRequest] = OutputTag[TestJobRequest]("test-job-request-stream-tag")
+  val mapOutputTag: OutputTag[util.Map[String, AnyRef]] = new OutputTag[util.Map[String, AnyRef]]("test-map-stream-tag", mapTypeInfo)
+  val stringOutputTag: OutputTag[String] = new OutputTag[String]("test-string-stream-tag", TypeInformation.of(classOf[String]))
+  val jobRequestOutputTag: OutputTag[TestJobRequest] = new OutputTag[TestJobRequest]("test-job-request-stream-tag", jobReqTypeInfo)
 
   val kafkaMapInputTopic: String = config.getString("kafka.map.input.topic")
   val kafkaMapOutputTopic: String = config.getString("kafka.map.output.topic")

--- a/jobs-core/src/test/scala/org/sunbird/spec/CoreTestSpec.scala
+++ b/jobs-core/src/test/scala/org/sunbird/spec/CoreTestSpec.scala
@@ -3,7 +3,7 @@ package org.sunbird.spec
 import java.util
 
 import com.typesafe.config.{Config, ConfigFactory}
-import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.util.Collector
 import org.scalatest.Matchers
 import org.scalatestplus.mockito.MockitoSugar

--- a/jobs-distribution/Dockerfile
+++ b/jobs-distribution/Dockerfile
@@ -1,4 +1,4 @@
-FROM flink:1.18.1-scala_2.12-java11 AS base
+FROM flink:1.20.5-java11 AS base
 
 USER root
 RUN apt-get update && apt-get dist-upgrade -y && \
@@ -19,7 +19,7 @@ ENV cloud_storage_auth_type=OIDC
 FROM base AS azure
 ENV cloud_storage_type=azure
 RUN mkdir -p $FLINK_HOME/plugins/azure-fs-hadoop && \
-    cp $FLINK_HOME/opt/flink-azure-fs-hadoop-1.18.1.jar $FLINK_HOME/plugins/azure-fs-hadoop/
+    cp $FLINK_HOME/opt/flink-azure-fs-hadoop-1.20.5.jar $FLINK_HOME/plugins/azure-fs-hadoop/
 COPY target/azure-plugin/ $FLINK_HOME/plugins/azure-fs-hadoop/
 USER flink
 
@@ -28,12 +28,12 @@ FROM base AS gcloud
 ENV cloud_storage_type=gcloud
 COPY lib/gcs-connector-hadoop2-2.2.0.jar $FLINK_HOME/lib/
 RUN mkdir -p $FLINK_HOME/plugins/gs-fs-hadoop && \
-    cp $FLINK_HOME/opt/flink-gs-fs-hadoop-1.18.1.jar $FLINK_HOME/plugins/gs-fs-hadoop/
+    cp $FLINK_HOME/opt/flink-gs-fs-hadoop-1.20.5.jar $FLINK_HOME/plugins/gs-fs-hadoop/
 USER flink
 
 # ── AWS ────────────────────────────────────────────────────────────────────
 FROM base AS aws
 ENV cloud_storage_type=aws
 RUN mkdir -p $FLINK_HOME/plugins/s3-fs-presto && \
-    cp $FLINK_HOME/opt/flink-s3-fs-presto-1.18.1.jar $FLINK_HOME/plugins/s3-fs-presto/
+    cp $FLINK_HOME/opt/flink-s3-fs-presto-1.20.5.jar $FLINK_HOME/plugins/s3-fs-presto/
 USER flink

--- a/jobs-distribution/pom.xml
+++ b/jobs-distribution/pom.xml
@@ -16,7 +16,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <type>jar</type>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<scala.version>2.12</scala.version>
 		<scala.maj.version>2.12.19</scala.maj.version>
-		<flink.version>1.18.1</flink.version>
+		<flink.version>1.20.5</flink.version>
 		<kafka.version>3.9.2</kafka.version>
 		<jackson-jaxrs.version>1.9.13</jackson-jaxrs.version>
 		<scoverage.plugin.version>1.4.0</scoverage.plugin.version>
@@ -133,7 +133,7 @@
 			<dependency>
 				<groupId>commons-io</groupId>
 				<artifactId>commons-io</artifactId>
-				<version>2.14.0</version>
+				<version>2.15.1</version>
 			</dependency>
 			<dependency>
 				<groupId>org.xerial.snappy</groupId>

--- a/publish-pipeline/knowlg-publish/pom.xml
+++ b/publish-pipeline/knowlg-publish/pom.xml
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -108,6 +108,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/publish-pipeline/knowlg-publish/src/main/resources/log4j.properties
+++ b/publish-pipeline/knowlg-publish/src/main/resources/log4j.properties
@@ -1,14 +1,25 @@
-# log4j.appender.file=org.apache.log4j.FileAppender
-log4j.appender.file=org.apache.log4j.RollingFileAppender
-log4j.appender.file.file=-content-publish.log
-log4j.appender.file.append=true
-log4j.appender.file.layout=org.apache.log4j.PatternLayout
-log4j.appender.file.MaxFileSize=256KB
-log4j.appender.file.MaxBackupIndex=4
-log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+# Root Logger configuration
+rootLogger.level = INFO
+rootLogger.appenderRef.file.ref = RollingFile
 
-# Suppress the irrelevant (wrong) warnings from the Netty channel handler
-log4j.logger.org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, file
+# File Appender
+appender.file.type = RollingFile
+appender.file.name = RollingFile
+appender.file.fileName = -content-embedding.log
+appender.file.filePattern = -content-embedding-%i.log
+appender.file.append = true
+appender.file.layout.type = PatternLayout
+appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+appender.file.policies.type = Policies
+appender.file.policies.size.type = SizeBasedTriggeringPolicy
+appender.file.policies.size.size = 256KB
+appender.file.strategy.type = DefaultRolloverStrategy
+appender.file.strategy.max = 4
 
-# Suppress known Flink Sink V2 Committer metric registration bug (FLINK-37559) — harmless, doesn't affect commits
-log4j.logger.org.apache.flink.metrics.MetricGroup=ERROR, file
+# Suppress Netty channel handler warnings
+logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline
+logger.netty.level = ERROR
+
+# Suppress Sink V2 Committer metric bug (FLINK-37559)
+logger.flink_metrics.name = org.apache.flink.metrics
+logger.flink_metrics.level = ERROR

--- a/publish-pipeline/knowlg-publish/src/main/resources/log4j.properties
+++ b/publish-pipeline/knowlg-publish/src/main/resources/log4j.properties
@@ -5,8 +5,8 @@ rootLogger.appenderRef.file.ref = RollingFile
 # File Appender
 appender.file.type = RollingFile
 appender.file.name = RollingFile
-appender.file.fileName = -content-embedding.log
-appender.file.filePattern = -content-embedding-%i.log
+appender.file.fileName = -content-publish.log
+appender.file.filePattern = -content-publish-%i.log
 appender.file.append = true
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
@@ -21,5 +21,5 @@ logger.netty.name = org.apache.flink.shaded.akka.org.jboss.netty.channel.Default
 logger.netty.level = ERROR
 
 # Suppress Sink V2 Committer metric bug (FLINK-37559)
-logger.flink_metrics.name = org.apache.flink.metrics
+logger.flink_metrics.name = org.apache.flink.metrics.MetricGroup
 logger.flink_metrics.level = ERROR

--- a/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/publish/processor/XMLLoaderWithCData.scala
+++ b/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/publish/processor/XMLLoaderWithCData.scala
@@ -11,7 +11,7 @@ object XMLLoaderWithCData extends XMLLoader[Elem] {
 	def lexicalHandler(adapter: FactoryAdapter): LexicalHandler =
 		new DefaultHandler2 {
 			def captureCData(): Unit = {
-				adapter.hStack push PCData(adapter.buffer.toString)
+				adapter.hStack = PCData(adapter.buffer.toString) :: adapter.hStack
 				adapter.buffer.clear()
 			}
 
@@ -27,9 +27,9 @@ object XMLLoaderWithCData extends XMLLoader[Elem] {
 			"http://xml.org/sax/properties/lexical-handler",
 			lexicalHandler(newAdapter))
 
-		newAdapter.scopeStack push TopScope
+		newAdapter.scopeStack = TopScope :: newAdapter.scopeStack
 		parser.parse(source, newAdapter)
-		newAdapter.scopeStack.pop()
+		newAdapter.scopeStack = newAdapter.scopeStack.tail
 
 		newAdapter.rootElem.asInstanceOf[Elem]
 	}

--- a/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/task/KnowlgPublishConfig.scala
+++ b/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/task/KnowlgPublishConfig.scala
@@ -3,7 +3,7 @@ package org.sunbird.job.knowlg.task
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.publish.config.PublishConfig
 import org.sunbird.job.knowlg.publish.domain.Event
 
@@ -85,19 +85,19 @@ class KnowlgPublishConfig(override val config: Config) extends PublishConfig(con
   val questionSetPublishFailedEventCount = "questionset-publish-failed-count"
 
   // Out Tags
-  val contentPublishOutTag: OutputTag[Event] = OutputTag[Event]("content-publish")
-  val collectionPublishOutTag: OutputTag[Event] = OutputTag[Event]("collection-publish")
-  val questionPublishOutTag: OutputTag[Event] = OutputTag[Event]("question-publish")
-  val questionSetPublishOutTag: OutputTag[Event] = OutputTag[Event]("questionset-publish")
-  val generateVideoStreamingOutTag: OutputTag[String] = OutputTag[String]("video-streaming-generator-request")
-  val failedEventOutTag: OutputTag[String] = OutputTag[String]("failed-event")
-  val generatePostPublishProcessTag: OutputTag[String] = OutputTag[String]("post-publish-process-request")
-  val mvcProcessorTag: OutputTag[String] = OutputTag[String]("mvc-processor-request")
-  val dialcodeContextUpdaterOutTag: OutputTag[String] = OutputTag[String]("dialcode-context-updater-request")
-  val contentMetadataEventOutTag: OutputTag[String] = OutputTag[String]("content-metadata-event-request")
-  val enrichedMetadataEventOutTag: OutputTag[String] = OutputTag[String]("enriched-metadata-event-request")
-  val enrichOnlyOutTag: OutputTag[Event] = OutputTag[Event]("enrich-only-request")
-  val qrimageOutTag: OutputTag[String] = OutputTag[String]("qrimage-generator-request")
+  val contentPublishOutTag: OutputTag[Event] = new OutputTag[Event]("content-publish", publishMetaTypeInfo)
+  val collectionPublishOutTag: OutputTag[Event] = new OutputTag[Event]("collection-publish", publishMetaTypeInfo)
+  val questionPublishOutTag: OutputTag[Event] = new OutputTag[Event]("question-publish", publishMetaTypeInfo)
+  val questionSetPublishOutTag: OutputTag[Event] = new OutputTag[Event]("questionset-publish", publishMetaTypeInfo)
+  val generateVideoStreamingOutTag: OutputTag[String] = new OutputTag[String]("video-streaming-generator-request", stringTypeInfo)
+  val failedEventOutTag: OutputTag[String] = new OutputTag[String]("failed-event", stringTypeInfo)
+  val generatePostPublishProcessTag: OutputTag[String] = new OutputTag[String]("post-publish-process-request", stringTypeInfo)
+  val mvcProcessorTag: OutputTag[String] = new OutputTag[String]("mvc-processor-request", stringTypeInfo)
+  val dialcodeContextUpdaterOutTag: OutputTag[String] = new OutputTag[String]("dialcode-context-updater-request", stringTypeInfo)
+  val contentMetadataEventOutTag: OutputTag[String] = new OutputTag[String]("content-metadata-event-request", stringTypeInfo)
+  val enrichedMetadataEventOutTag: OutputTag[String] = new OutputTag[String]("enriched-metadata-event-request", stringTypeInfo)
+  val enrichOnlyOutTag: OutputTag[Event] = new OutputTag[Event]("enrich-only-request", publishMetaTypeInfo)
+  val qrimageOutTag: OutputTag[String] = new OutputTag[String]("qrimage-generator-request", stringTypeInfo)
 
 
   val definitionBasePath: String = if (config.hasPath("schema.basePath")) config.getString("schema.basePath") else "https://sunbirddev.blob.core.windows.net/sunbird-content-dev/schemas/local"

--- a/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/task/KnowlgPublishStreamTask.scala
+++ b/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/task/KnowlgPublishStreamTask.scala
@@ -5,7 +5,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.knowlg.function.{CollectionPublishFunction, ContentPublishFunction, EnrichOnlyFunction, PublishEventRouter, QuestionPublishFunction, QuestionSetPublishFunction}
 import org.sunbird.job.knowlg.publish.domain.Event

--- a/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/task/KnowlgPublishStreamTask.scala
+++ b/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/task/KnowlgPublishStreamTask.scala
@@ -49,56 +49,38 @@ class KnowlgPublishStreamTask(config: KnowlgPublishConfig, kafkaConnector: Flink
       .name("content-publish-process").uid("content-publish-process").setParallelism(1)
 
     contentPublish.getSideOutput(config.generateVideoStreamingOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.postPublishTopic))
-      .name("content-publish-postpublish-sink").uid("content-publish-postpublish-sink")
     contentPublish.getSideOutput(config.mvcProcessorTag).sinkTo(kafkaConnector.kafkaStringSink(config.mvcTopic))
-      .name("content-publish-mvc-sink").uid("content-publish-mvc-sink")
     contentPublish.getSideOutput(config.contentMetadataEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.contentMetadataTopic))
-      .name("content-publish-contentmetadata-sink").uid("content-publish-contentmetadata-sink")
     contentPublish.getSideOutput(config.enrichedMetadataEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.enrichedMetadataTopic))
-      .name("content-publish-enrichedmetadata-sink").uid("content-publish-enrichedmetadata-sink")
     contentPublish.getSideOutput(config.failedEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
-      .name("content-publish-error-sink").uid("content-publish-error-sink")
 
     val collectionPublish = processStreamTask.getSideOutput(config.collectionPublishOutTag).process(new CollectionPublishFunction(config, httpUtil))
       .name("collection-publish-process").uid("collection-publish-process").setParallelism(1)
     collectionPublish.getSideOutput(config.generatePostPublishProcessTag).sinkTo(kafkaConnector.kafkaStringSink(config.postPublishTopic))
-      .name("collection-publish-postpublish-sink").uid("collection-publish-postpublish-sink")
     collectionPublish.getSideOutput(config.enrichedMetadataEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.enrichedMetadataTopic))
-      .name("collection-publish-enrichedmetadata-sink").uid("collection-publish-enrichedmetadata-sink")
     collectionPublish.getSideOutput(config.failedEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
-      .name("collection-publish-error-sink").uid("collection-publish-error-sink")
 
     if (config.enableDIALContextUpdate.equalsIgnoreCase("Yes")) {
       contentPublish.getSideOutput(config.dialcodeContextUpdaterOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.dialcodeContextUpdaterTopic))
-        .name("content-publish-dialcode-sink").uid("content-publish-dialcode-sink")
       contentPublish.getSideOutput(config.qrimageOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.qrimageTopic))
-        .name("content-publish-qrimage-sink").uid("content-publish-qrimage-sink")
       collectionPublish.getSideOutput(config.dialcodeContextUpdaterOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.dialcodeContextUpdaterTopic))
-        .name("collection-publish-dialcode-sink").uid("collection-publish-dialcode-sink")
       collectionPublish.getSideOutput(config.qrimageOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.qrimageTopic))
-        .name("collection-publish-qrimage-sink").uid("collection-publish-qrimage-sink")
     }
 
     val questionPublish = processStreamTask.getSideOutput(config.questionPublishOutTag).process(new QuestionPublishFunction(config, httpUtil))
       .name("question-publish-process").uid("question-publish-process").setParallelism(1)
     questionPublish.getSideOutput(config.enrichedMetadataEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.enrichedMetadataTopic))
-      .name("question-publish-enrichedmetadata-sink").uid("question-publish-enrichedmetadata-sink")
     questionPublish.getSideOutput(config.failedEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
-      .name("question-publish-error-sink").uid("question-publish-error-sink")
 
     val questionSetPublish = processStreamTask.getSideOutput(config.questionSetPublishOutTag).process(new QuestionSetPublishFunction(config, httpUtil))
       .name("questionset-publish-process").uid("questionset-publish-process").setParallelism(1)
     questionSetPublish.getSideOutput(config.enrichedMetadataEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.enrichedMetadataTopic))
-      .name("questionset-publish-enrichedmetadata-sink").uid("questionset-publish-enrichedmetadata-sink")
     questionSetPublish.getSideOutput(config.failedEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
-      .name("questionset-publish-error-sink").uid("questionset-publish-error-sink")
 
     val enrichOnly = processStreamTask.getSideOutput(config.enrichOnlyOutTag).process(new EnrichOnlyFunction(config))
       .name("enrich-only-process").uid("enrich-only-process").setParallelism(1)
     enrichOnly.getSideOutput(config.enrichedMetadataEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.enrichedMetadataTopic))
-      .name("enrich-only-enrichedmetadata-sink").uid("enrich-only-enrichedmetadata-sink")
     enrichOnly.getSideOutput(config.failedEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
-      .name("enrich-only-error-sink").uid("enrich-only-error-sink")
   }
 }
 

--- a/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/task/KnowlgPublishStreamTask.scala
+++ b/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/task/KnowlgPublishStreamTask.scala
@@ -49,38 +49,56 @@ class KnowlgPublishStreamTask(config: KnowlgPublishConfig, kafkaConnector: Flink
       .name("content-publish-process").uid("content-publish-process").setParallelism(1)
 
     contentPublish.getSideOutput(config.generateVideoStreamingOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.postPublishTopic))
+      .name("content-publish-postpublish-sink").uid("content-publish-postpublish-sink")
     contentPublish.getSideOutput(config.mvcProcessorTag).sinkTo(kafkaConnector.kafkaStringSink(config.mvcTopic))
+      .name("content-publish-mvc-sink").uid("content-publish-mvc-sink")
     contentPublish.getSideOutput(config.contentMetadataEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.contentMetadataTopic))
+      .name("content-publish-contentmetadata-sink").uid("content-publish-contentmetadata-sink")
     contentPublish.getSideOutput(config.enrichedMetadataEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.enrichedMetadataTopic))
+      .name("content-publish-enrichedmetadata-sink").uid("content-publish-enrichedmetadata-sink")
     contentPublish.getSideOutput(config.failedEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
+      .name("content-publish-error-sink").uid("content-publish-error-sink")
 
     val collectionPublish = processStreamTask.getSideOutput(config.collectionPublishOutTag).process(new CollectionPublishFunction(config, httpUtil))
       .name("collection-publish-process").uid("collection-publish-process").setParallelism(1)
     collectionPublish.getSideOutput(config.generatePostPublishProcessTag).sinkTo(kafkaConnector.kafkaStringSink(config.postPublishTopic))
+      .name("collection-publish-postpublish-sink").uid("collection-publish-postpublish-sink")
     collectionPublish.getSideOutput(config.enrichedMetadataEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.enrichedMetadataTopic))
+      .name("collection-publish-enrichedmetadata-sink").uid("collection-publish-enrichedmetadata-sink")
     collectionPublish.getSideOutput(config.failedEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
+      .name("collection-publish-error-sink").uid("collection-publish-error-sink")
 
     if (config.enableDIALContextUpdate.equalsIgnoreCase("Yes")) {
       contentPublish.getSideOutput(config.dialcodeContextUpdaterOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.dialcodeContextUpdaterTopic))
+        .name("content-publish-dialcode-sink").uid("content-publish-dialcode-sink")
       contentPublish.getSideOutput(config.qrimageOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.qrimageTopic))
+        .name("content-publish-qrimage-sink").uid("content-publish-qrimage-sink")
       collectionPublish.getSideOutput(config.dialcodeContextUpdaterOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.dialcodeContextUpdaterTopic))
+        .name("collection-publish-dialcode-sink").uid("collection-publish-dialcode-sink")
       collectionPublish.getSideOutput(config.qrimageOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.qrimageTopic))
+        .name("collection-publish-qrimage-sink").uid("collection-publish-qrimage-sink")
     }
 
     val questionPublish = processStreamTask.getSideOutput(config.questionPublishOutTag).process(new QuestionPublishFunction(config, httpUtil))
       .name("question-publish-process").uid("question-publish-process").setParallelism(1)
     questionPublish.getSideOutput(config.enrichedMetadataEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.enrichedMetadataTopic))
+      .name("question-publish-enrichedmetadata-sink").uid("question-publish-enrichedmetadata-sink")
     questionPublish.getSideOutput(config.failedEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
+      .name("question-publish-error-sink").uid("question-publish-error-sink")
 
     val questionSetPublish = processStreamTask.getSideOutput(config.questionSetPublishOutTag).process(new QuestionSetPublishFunction(config, httpUtil))
       .name("questionset-publish-process").uid("questionset-publish-process").setParallelism(1)
     questionSetPublish.getSideOutput(config.enrichedMetadataEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.enrichedMetadataTopic))
+      .name("questionset-publish-enrichedmetadata-sink").uid("questionset-publish-enrichedmetadata-sink")
     questionSetPublish.getSideOutput(config.failedEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
+      .name("questionset-publish-error-sink").uid("questionset-publish-error-sink")
 
     val enrichOnly = processStreamTask.getSideOutput(config.enrichOnlyOutTag).process(new EnrichOnlyFunction(config))
       .name("enrich-only-process").uid("enrich-only-process").setParallelism(1)
     enrichOnly.getSideOutput(config.enrichedMetadataEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.enrichedMetadataTopic))
+      .name("enrich-only-enrichedmetadata-sink").uid("enrich-only-enrichedmetadata-sink")
     enrichOnly.getSideOutput(config.failedEventOutTag).sinkTo(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
+      .name("enrich-only-error-sink").uid("enrich-only-error-sink")
   }
 }
 

--- a/publish-pipeline/live-node-publisher/pom.xml
+++ b/publish-pipeline/live-node-publisher/pom.xml
@@ -20,7 +20,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -103,6 +103,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/publish-pipeline/live-node-publisher/src/main/scala/org/sunbird/job/livenodepublisher/publish/processor/XMLLoaderWithCData.scala
+++ b/publish-pipeline/live-node-publisher/src/main/scala/org/sunbird/job/livenodepublisher/publish/processor/XMLLoaderWithCData.scala
@@ -11,7 +11,7 @@ object XMLLoaderWithCData extends XMLLoader[Elem] {
 	def lexicalHandler(adapter: FactoryAdapter): LexicalHandler =
 		new DefaultHandler2 {
 			def captureCData(): Unit = {
-				adapter.hStack push PCData(adapter.buffer.toString)
+				adapter.hStack = PCData(adapter.buffer.toString) :: adapter.hStack
 				adapter.buffer.clear()
 			}
 
@@ -27,9 +27,9 @@ object XMLLoaderWithCData extends XMLLoader[Elem] {
 			"http://xml.org/sax/properties/lexical-handler",
 			lexicalHandler(newAdapter))
 
-		newAdapter.scopeStack push TopScope
+		newAdapter.scopeStack = TopScope :: newAdapter.scopeStack
 		parser.parse(source, newAdapter)
-		newAdapter.scopeStack.pop()
+		newAdapter.scopeStack = newAdapter.scopeStack.tail
 
 		newAdapter.rootElem.asInstanceOf[Elem]
 	}

--- a/publish-pipeline/live-node-publisher/src/main/scala/org/sunbird/job/livenodepublisher/task/LiveNodePublisherConfig.scala
+++ b/publish-pipeline/live-node-publisher/src/main/scala/org/sunbird/job/livenodepublisher/task/LiveNodePublisherConfig.scala
@@ -3,7 +3,7 @@ package org.sunbird.job.livenodepublisher.task
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.publish.config.PublishConfig
 import org.sunbird.job.livenodepublisher.publish.domain.Event
 
@@ -59,12 +59,12 @@ class LiveNodePublisherConfig(override val config: Config) extends PublishConfig
   val nodeStore: Int = if (redisEnabled) config.getInt("redis.database.contentCache.id") else 0
 
   // Out Tags
-  val contentPublishOutTag: OutputTag[Event] = OutputTag[Event]("live-content-publish")
-  val collectionPublishOutTag: OutputTag[Event] = OutputTag[Event]("live-collection-publish")
-  val generateVideoStreamingOutTag: OutputTag[String] = OutputTag[String]("live-video-streaming-generator-request")
-  val failedEventOutTag: OutputTag[String] = OutputTag[String]("failed-event")
-  val skippedEventOutTag: OutputTag[String] = OutputTag[String]("skipped-event")
-  val generatePostPublishProcessTag: OutputTag[String] = OutputTag[String]("post-publish-process-request")
+  val contentPublishOutTag: OutputTag[Event] = new OutputTag[Event]("live-content-publish", publishMetaTypeInfo)
+  val collectionPublishOutTag: OutputTag[Event] = new OutputTag[Event]("live-collection-publish", publishMetaTypeInfo)
+  val generateVideoStreamingOutTag: OutputTag[String] = new OutputTag[String]("live-video-streaming-generator-request", stringTypeInfo)
+  val failedEventOutTag: OutputTag[String] = new OutputTag[String]("failed-event", stringTypeInfo)
+  val skippedEventOutTag: OutputTag[String] = new OutputTag[String]("skipped-event", stringTypeInfo)
+  val generatePostPublishProcessTag: OutputTag[String] = new OutputTag[String]("post-publish-process-request", stringTypeInfo)
 
   // Service Urls
   val printServiceBaseUrl: String = config.getString("service.print.basePath")

--- a/publish-pipeline/live-node-publisher/src/main/scala/org/sunbird/job/livenodepublisher/task/LiveNodePublisherStreamTask.scala
+++ b/publish-pipeline/live-node-publisher/src/main/scala/org/sunbird/job/livenodepublisher/task/LiveNodePublisherStreamTask.scala
@@ -5,7 +5,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.livenodepublisher.function.{LiveCollectionPublishFunction, LiveContentPublishFunction, LivePublishEventRouter}
 import org.sunbird.job.livenodepublisher.publish.domain.Event

--- a/qrcode-image-generator/pom.xml
+++ b/qrcode-image-generator/pom.xml
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -120,6 +120,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/qrcode-image-generator/src/main/scala/org/sunbird/job/qrimagegenerator/task/QRCodeImageGeneratorConfig.scala
+++ b/qrcode-image-generator/src/main/scala/org/sunbird/job/qrimagegenerator/task/QRCodeImageGeneratorConfig.scala
@@ -4,7 +4,7 @@ import com.typesafe.config.Config
 import org.apache.commons.lang3.StringUtils
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.BaseJobConfig
 import org.sunbird.job.qrimagegenerator.domain.Event
 
@@ -30,7 +30,7 @@ class QRCodeImageGeneratorConfig(override val config: Config) extends BaseJobCon
   val cloudDbFailCount = "cloud-db-hit-failure-count"
 
   //Tags
-  val indexImageUrlOutTag: OutputTag[Event] = OutputTag[Event]("index-imageUrl")
+  val indexImageUrlOutTag: OutputTag[Event] = new OutputTag[Event]("index-imageUrl", qrImageTypeInfo)
 
   // ES Configs
   val esConnectionInfo = config.getString("es.basePath")

--- a/qrcode-image-generator/src/main/scala/org/sunbird/job/qrimagegenerator/task/QRCodeImageGeneratorTask.scala
+++ b/qrcode-image-generator/src/main/scala/org/sunbird/job/qrimagegenerator/task/QRCodeImageGeneratorTask.scala
@@ -5,7 +5,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.qrimagegenerator.domain.Event
 import org.sunbird.job.qrimagegenerator.functions.{QRCodeImageGeneratorFunction, QRCodeIndexImageUrlFunction}

--- a/transaction-event-processor/pom.xml
+++ b/transaction-event-processor/pom.xml
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
 <!--            <scope>provided</scope>-->
         </dependency>
@@ -150,6 +150,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/transaction-event-processor/src/main/resources/log4j.properties
+++ b/transaction-event-processor/src/main/resources/log4j.properties
@@ -9,5 +9,7 @@ log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-
 # Suppress the irrelevant (wrong) warnings from the Netty channel handler
 log4j.logger.org.apache.flink.shaded.akka.org.jboss.netty.channel.DefaultChannelPipeline=ERROR, file
 
+# Suppress known Flink Sink V2 Committer metric registration bug (FLINK-37559) — harmless, doesn't affect commits
+log4j.logger.org.apache.flink.metrics.MetricGroup=ERROR, file
 
 

--- a/transaction-event-processor/src/main/scala/org/sunbird/job/transaction/task/TransactionEventProcessorConfig.scala
+++ b/transaction-event-processor/src/main/scala/org/sunbird/job/transaction/task/TransactionEventProcessorConfig.scala
@@ -4,7 +4,7 @@ import java.util
 import com.typesafe.config.Config
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
-import org.apache.flink.streaming.api.scala.OutputTag
+import org.apache.flink.util.OutputTag
 import org.sunbird.job.BaseJobConfig
 import org.sunbird.job.transaction.domain.Event
 import scala.collection.JavaConverters._
@@ -75,17 +75,17 @@ class TransactionEventProcessorConfig(override val config: Config)
       config.getBoolean("job.dialcode-metrics-indexer")
     else true
 
-  val outputTag: OutputTag[Event] = OutputTag[Event]("output-tag")
-  val auditOutputTag: OutputTag[String] = OutputTag[String]("audit-event-tag")
+  val outputTag: OutputTag[Event] = new OutputTag[Event]("output-tag", eventTypeInfo)
+  val auditOutputTag: OutputTag[String] = new OutputTag[String]("audit-event-tag", stringTypeInfo)
   val obsrvAuditOutputTag: OutputTag[String] =
-    OutputTag[String]("obsrv-metadata-tag")
+    new OutputTag[String]("obsrv-metadata-tag", stringTypeInfo)
   val compositeSearchDataOutTag: OutputTag[Event] =
-    OutputTag[Event]("composite-search-data")
+    new OutputTag[Event]("composite-search-data", eventTypeInfo)
   val dialCodeExternalOutTag: OutputTag[Event] =
-    OutputTag[Event]("dialcode-external")
+    new OutputTag[Event]("dialcode-external", eventTypeInfo)
   val dialCodeMetricOutTag: OutputTag[Event] =
-    OutputTag[Event]("dialcode-metric")
-  val failedEventOutTag: OutputTag[String] = OutputTag[String]("failed-event")
+    new OutputTag[Event]("dialcode-metric", eventTypeInfo)
+  val failedEventOutTag: OutputTag[String] = new OutputTag[String]("failed-event", stringTypeInfo)
 
   val defaultChannel: String = config.getString("channel.default")
 

--- a/transaction-event-processor/src/main/scala/org/sunbird/job/transaction/task/TransactionEventProcessorStreamTask.scala
+++ b/transaction-event-processor/src/main/scala/org/sunbird/job/transaction/task/TransactionEventProcessorStreamTask.scala
@@ -8,7 +8,8 @@ import org.apache.flink.api.java.functions.KeySelector
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.slf4j.LoggerFactory
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.transaction.domain.Event

--- a/transaction-event-processor/src/test/scala/org/sunbird/job/spec/TransactionEventProcessorTaskTestSpec.scala
+++ b/transaction-event-processor/src/test/scala/org/sunbird/job/spec/TransactionEventProcessorTaskTestSpec.scala
@@ -10,7 +10,7 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration
 import org.apache.flink.streaming.api.functions.sink.SinkFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction
 import org.apache.flink.streaming.api.functions.source.SourceFunction.SourceContext
-import org.apache.flink.streaming.api.scala.DataStream
+import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.test.util.MiniClusterWithClientResource
 import org.mockito.ArgumentMatchers.any
 import org.sunbird.job.util.{ElasticSearchUtil, JSONUtil}
@@ -412,7 +412,7 @@ class TestableTransactionEventProcessorStreamTask(
     testSinks: Map[String, SinkFunction[String]]
 ) extends TransactionEventProcessorStreamTask(config, kafkaConnector, esUtil) {
 
-  import org.apache.flink.streaming.api.scala.DataStream
+  import org.apache.flink.streaming.api.datastream.DataStream
 
   override protected def stringSink(
       stream: DataStream[String],

--- a/video-stream-generator/pom.xml
+++ b/video-stream-generator/pom.xml
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-scala_${scala.version}</artifactId>
+            <artifactId>flink-streaming-java</artifactId>
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
@@ -153,6 +153,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <artifactSet>
                                 <excludes>
                                     <exclude>com.google.code.findbugs:jsr305</exclude>

--- a/video-stream-generator/src/main/scala/org/sunbird/job/videostream/task/VideoStreamGeneratorStreamTask.scala
+++ b/video-stream-generator/src/main/scala/org/sunbird/job/videostream/task/VideoStreamGeneratorStreamTask.scala
@@ -7,7 +7,8 @@ import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.TypeExtractor
 import org.apache.flink.api.java.utils.ParameterTool
 import org.apache.flink.api.common.eventtime.WatermarkStrategy
-import org.apache.flink.streaming.api.scala.{DataStream, StreamExecutionEnvironment}
+import org.apache.flink.streaming.api.datastream.DataStream
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.sunbird.job.connector.FlinkKafkaConnector
 import org.sunbird.job.videostream.domain.Event
 import org.sunbird.job.videostream.functions.VideoStreamGenerator


### PR DESCRIPTION
Upgrades Apache Flink from 1.18.1 to 1.20.5 across the full reactor (11 modules pinned via root `pom.xml`). Migrates every module off the deprecated `flink-streaming-scala` API (removed in Flink 2.0, FLINK-37248) onto the Java `DataStream`/`StreamExecutionEnvironment`/`OutputTag`/`ProcessWindowFunction` APIs, since job logic already used Java `ProcessFunction`/`KeyedProcessFunction` rather than Scala closures on Flink types.

Also bumps `jobs-distribution/Dockerfile`'s base image and fs-plugin jar references from `1.18.1` to `1.20.5` (Flink dropped scala-suffixed image variants), and updates `README.md`'s local-dev instructions (Flink download version, IntelliJ debug-mode temporary pom snippets) to match the new dependency shape.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Test Configuration**:
* Software versions: Flink 1.20.5, Java 11, Scala 2.12, Maven 3.8+
* Hardware versions: macOS (arm64)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-und
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my chan
- [ ] Any dependent changes have been merged and published in downstream modules