### PR TITLE
fix: added redis for collection hierarchy

### DIFF
--- a/publish-pipeline/knowlg-publish/src/main/resources/content-publish.conf
+++ b/publish-pipeline/knowlg-publish/src/main/resources/content-publish.conf
@@ -82,6 +82,7 @@ redis {
   database {
     contentCache.id = 0
     qsCache.id = 1
+    hierarchyRelations.id = 10
   }
 }
 

--- a/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/function/CollectionPublishFunction.scala
+++ b/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/function/CollectionPublishFunction.scala
@@ -37,6 +37,7 @@ class CollectionPublishFunction(config: KnowlgPublishConfig, httpUtil: HttpUtil,
   private[this] val logger = LoggerFactory.getLogger(classOf[CollectionPublishFunction])
   val mapType: Type = new TypeToken[java.util.Map[String, AnyRef]]() {}.getType
   private var cache: DataCache = _
+  private var hierarchyRelationsCache: DataCache = _
   private val COLLECTION_CACHE_KEY_PREFIX = "hierarchy_"
   private val COLLECTION_CACHE_KEY_SUFFIX = ":leafnodes"
   private var fieldConfig: FieldConfiguration = _
@@ -56,6 +57,8 @@ class CollectionPublishFunction(config: KnowlgPublishConfig, httpUtil: HttpUtil,
     definitionConfig = DefinitionConfig(config.schemaSupportVersionMap, config.definitionBasePath)
     cache = new DataCache(config, new RedisConnect(config), config.nodeStore, List())
     cache.init()
+    hierarchyRelationsCache = new DataCache(config, new RedisConnect(config), config.hierarchyRelationsDbId, List())
+    hierarchyRelationsCache.init()
     fieldConfig = new FieldConfiguration(config.getConfig())
     enrichedMetadataEventBuilder = new ConfigurableEnrichedMetadataEventBuilder(fieldConfig, config.enrichedMetadataTopic, config.includeHierarchyInEnrichedMetadata)
   }
@@ -64,6 +67,7 @@ class CollectionPublishFunction(config: KnowlgPublishConfig, httpUtil: HttpUtil,
     super.close()
     cassandraUtil.close()
     cache.close()
+    hierarchyRelationsCache.close()
   }
 
   override def metricsList(): List[String] = {
@@ -133,7 +137,7 @@ class CollectionPublishFunction(config: KnowlgPublishConfig, httpUtil: HttpUtil,
           logger.info(s"KN-856: Step:8 - After publishHierarchy Collection:  ${successObj.identifier} | Hierarchy: $updatedChildren");
           
           // Update collection hierarchy relationships - use enrichedObj which has complete hierarchy
-          updateHierarchyRelationships(enrichedObj)(cassandraUtil, config)
+          updateHierarchyRelationships(enrichedObj, hierarchyRelationsCache)(cassandraUtil, config)
           logger.info(s"After updateHierarchyRelationships Collection:  ${enrichedObj.identifier}");
 
           //TODO: Save IMAGE Object with enrichedObj children and collRelationalMetadata when pkgVersion is 1 - verify with MaheshG

--- a/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/publish/helpers/CollectionPublisher.scala
+++ b/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/publish/helpers/CollectionPublisher.scala
@@ -860,13 +860,13 @@ trait CollectionPublisher extends ObjectReader with SyncMessagesGenerator with O
     if (CollectionUtils.isEmpty(children)) List().asJava else children
   }
 
-  private def storeRelationshipData(rootId: String, relationshipType: String, dataMap: Map[String, List[String]], dataCache: DataCache)
+  protected def storeRelationshipData(rootId: String, relationshipType: String, dataMap: Map[String, List[String]], dataCache: DataCache)
                                    (implicit cassandraUtil: CassandraUtil, config: KnowlgPublishConfig): Unit = {
     try {
       dataMap.foreach { case (identifier, nodeIds) =>
         val relationshipKey = if (StringUtils.isNotBlank(rootId)) s"${rootId}:${identifier}:${relationshipType}" else s"${identifier}:${relationshipType}"
         if (config.redisEnabled) {
-          dataCache.setWithRetry(relationshipKey, ScalaJsonUtil.serialize(nodeIds))
+          dataCache.createListWithRetry(relationshipKey, nodeIds)
         } else {
           val insertQuery = QueryBuilder.insertInto(config.collectionHierarchyKeyspaceName, config.collectionHierarchyTableName)
           insertQuery.value("relationship_key", relationshipKey)

--- a/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/publish/helpers/CollectionPublisher.scala
+++ b/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/publish/helpers/CollectionPublisher.scala
@@ -7,6 +7,7 @@ import org.apache.commons.collections.{CollectionUtils, MapUtils}
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.StringUtils
 import org.slf4j.LoggerFactory
+import org.sunbird.job.cache.DataCache
 import org.sunbird.job.knowlg.task.KnowlgPublishConfig
 import org.sunbird.job.domain.`object`.{DefinitionCache, ObjectDefinition}
 import org.sunbird.job.exception.InvalidInputException
@@ -722,24 +723,24 @@ trait CollectionPublisher extends ObjectReader with SyncMessagesGenerator with O
    * @param cassandraUtil Cassandra utility instance
    * @param config Configuration object
    */
-  def updateHierarchyRelationships(obj: ObjectData)(implicit cassandraUtil: CassandraUtil, config: KnowlgPublishConfig): Unit = {
+  def updateHierarchyRelationships(obj: ObjectData, dataCache: DataCache)(implicit cassandraUtil: CassandraUtil, config: KnowlgPublishConfig): Unit = {
     try {
       val rootId = obj.identifier.replace(".img", "")
       val hierarchy = getHierarchyFromDb(rootId)
-      
+
       if (MapUtils.isNotEmpty(hierarchy)) {
         val leafNodesMap = getLeafNodes(rootId, hierarchy)
         logger.info("Leaf-nodes cache updating for: " + leafNodesMap.size)
-        storeRelationshipData(rootId, "leafnodes", leafNodesMap)
-        
+        storeRelationshipData(rootId, "leafnodes", leafNodesMap, dataCache)
+
         val optionalNodesMap = getOptionalNodes(rootId, hierarchy)
         logger.info("Optional-nodes cache updating for: " + optionalNodesMap.size)
-        storeRelationshipData(rootId, "optionalnodes", optionalNodesMap)
-        
+        storeRelationshipData(rootId, "optionalnodes", optionalNodesMap, dataCache)
+
         val ancestorsMap = getAncestors(rootId, hierarchy)
         logger.info("Ancestors cache updating for: "+ ancestorsMap.size)
-        storeRelationshipData(rootId, "ancestors", ancestorsMap)
-        
+        storeRelationshipData(rootId, "ancestors", ancestorsMap, dataCache)
+
         logger.info(s"Hierarchy relationships updated for collection: $rootId")
       } else {
         logger.warn("Hierarchy Empty: " + obj.identifier)
@@ -859,18 +860,22 @@ trait CollectionPublisher extends ObjectReader with SyncMessagesGenerator with O
     if (CollectionUtils.isEmpty(children)) List().asJava else children
   }
 
-  private def storeRelationshipData(rootId: String, relationshipType: String, dataMap: Map[String, List[String]])
+  private def storeRelationshipData(rootId: String, relationshipType: String, dataMap: Map[String, List[String]], dataCache: DataCache)
                                    (implicit cassandraUtil: CassandraUtil, config: KnowlgPublishConfig): Unit = {
     try {
       dataMap.foreach { case (identifier, nodeIds) =>
         val relationshipKey = if (StringUtils.isNotBlank(rootId)) s"${rootId}:${identifier}:${relationshipType}" else s"${identifier}:${relationshipType}"
-        val insertQuery = QueryBuilder.insertInto(config.collectionHierarchyKeyspaceName, config.collectionHierarchyTableName)
-        insertQuery.value("relationship_key", relationshipKey)
-        insertQuery.value("node_ids", nodeIds.asJava)
-        
-        val result = cassandraUtil.upsert(insertQuery.toString)
-        if (!result) {
-          logger.error(s"Failed to store relationship data for key: $relationshipKey")
+        if (config.redisEnabled) {
+          dataCache.setWithRetry(relationshipKey, ScalaJsonUtil.serialize(nodeIds))
+        } else {
+          val insertQuery = QueryBuilder.insertInto(config.collectionHierarchyKeyspaceName, config.collectionHierarchyTableName)
+          insertQuery.value("relationship_key", relationshipKey)
+          insertQuery.value("node_ids", nodeIds.asJava)
+
+          val result = cassandraUtil.upsert(insertQuery.toString)
+          if (!result) {
+            logger.error(s"Failed to store relationship data for key: $relationshipKey")
+          }
         }
       }
     } catch {

--- a/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/task/KnowlgPublishConfig.scala
+++ b/publish-pipeline/knowlg-publish/src/main/scala/org/sunbird/job/knowlg/task/KnowlgPublishConfig.scala
@@ -68,6 +68,7 @@ class KnowlgPublishConfig(override val config: Config) extends PublishConfig(con
 
   // Redis Configurations
   val nodeStore: Int = if (redisEnabled) config.getInt("redis.database.contentCache.id") else 0
+  val hierarchyRelationsDbId: Int = if (config.hasPath("redis.database.hierarchyRelations.id")) config.getInt("redis.database.hierarchyRelations.id") else 10
 
   // Question/QuestionSet Configurations (merged from questionset-publish)
   val questionKeyspaceName: String = if (config.hasPath("question.keyspace")) config.getString("question.keyspace") else contentKeyspaceName

--- a/publish-pipeline/knowlg-publish/src/test/scala/org/sunbird/job/publish/helpers/spec/CollectionPublisherRedisSpec.scala
+++ b/publish-pipeline/knowlg-publish/src/test/scala/org/sunbird/job/publish/helpers/spec/CollectionPublisherRedisSpec.scala
@@ -1,0 +1,49 @@
+package org.sunbird.job.publish.helpers.spec
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.scalatest.{FlatSpec, Matchers}
+import org.sunbird.job.cache.{DataCache, RedisConnect}
+import org.sunbird.job.knowlg.task.KnowlgPublishConfig
+import org.sunbird.job.util.CassandraUtil
+
+import scala.collection.JavaConverters._
+
+/**
+ * Exercises only the Redis write path of CollectionPublisher.storeRelationshipData.
+ * No Cassandra, no JanusGraph, no cloud storage - just a local Redis.
+ */
+class CollectionPublisherRedisSpec extends FlatSpec with Matchers {
+
+  // Force redis.enabled=true for this spec regardless of what content-publish.conf/test.conf currently say.
+  val config: Config = ConfigFactory.parseString("redis.enabled = true")
+    .withFallback(ConfigFactory.load("test.conf").withFallback(ConfigFactory.systemEnvironment()))
+  val jobConfig = new KnowlgPublishConfig(config)
+  implicit val cassandraUtil: CassandraUtil = null // never touched on the redis-enabled branch
+
+  val rootId = "do_redis_test_root"
+  val unitId = "do_redis_test_unit1"
+  val leaf1Id = "do_redis_test_leaf1"
+  val leaf2Id = "do_redis_test_leaf2"
+
+  "storeRelationshipData" should "write leaf/optional/ancestor node ids to Redis when redis is enabled" in {
+    val redisConnect = new RedisConnect(jobConfig)
+    val dataCache = new DataCache(jobConfig, redisConnect, jobConfig.hierarchyRelationsDbId, List())
+    dataCache.init()
+    val jedis = redisConnect.getConnection(jobConfig.hierarchyRelationsDbId)
+    try {
+      val publisher = new TestCollectionPublisher()
+      publisher.testStoreRelationshipData(rootId, "leafnodes", Map(unitId -> List(leaf1Id, leaf2Id)), dataCache)(cassandraUtil, jobConfig)
+      publisher.testStoreRelationshipData(rootId, "optionalnodes", Map(unitId -> List(leaf2Id)), dataCache)(cassandraUtil, jobConfig)
+      publisher.testStoreRelationshipData(rootId, "ancestors", Map(leaf1Id -> List(unitId, rootId)), dataCache)(cassandraUtil, jobConfig)
+
+      jedis.smembers(s"$rootId:$unitId:leafnodes").asScala should contain theSameElementsAs List(leaf1Id, leaf2Id)
+      jedis.smembers(s"$rootId:$unitId:optionalnodes").asScala should contain theSameElementsAs List(leaf2Id)
+      jedis.smembers(s"$rootId:$leaf1Id:ancestors").asScala should contain theSameElementsAs List(unitId, rootId)
+    } finally {
+      jedis.del(s"$rootId:$unitId:leafnodes", s"$rootId:$unitId:optionalnodes", s"$rootId:$leaf1Id:ancestors")
+      jedis.close()
+      dataCache.close()
+    }
+  }
+
+}

--- a/publish-pipeline/knowlg-publish/src/test/scala/org/sunbird/job/publish/helpers/spec/CollectionPublisherSpec.scala
+++ b/publish-pipeline/knowlg-publish/src/test/scala/org/sunbird/job/publish/helpers/spec/CollectionPublisherSpec.scala
@@ -10,6 +10,7 @@ import org.mockito.Mockito
 import org.mockito.Mockito.{doNothing, when}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
+import org.sunbird.job.cache.{DataCache, RedisConnect}
 import org.sunbird.job.domain.`object`.{DefinitionCache, ObjectDefinition}
 import org.sunbird.job.knowlg.publish.helpers.CollectionPublisher
 import org.sunbird.job.knowlg.task.KnowlgPublishConfig
@@ -21,6 +22,7 @@ import org.sunbird.job.util._
 import java.text.SimpleDateFormat
 import java.util
 import java.util.Date
+import scala.collection.JavaConverters._
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContextExecutor
 
@@ -251,5 +253,38 @@ class CollectionPublisherSpec extends FlatSpec with BeforeAndAfterAll with Match
     result("language").asInstanceOf[Set[String]] should contain("English")
   }
 
+  "updateHierarchyRelationships" should "store leaf/optional/ancestor node ids in Redis when redis is enabled" in {
+    val rootId = "do_hier_test_root"
+    val unitId = "do_hier_test_unit1"
+    val leaf1Id = "do_hier_test_leaf1"
+    val leaf2Id = "do_hier_test_leaf2"
+    val hierarchyJson =
+      s"""{"identifier":"$rootId","mimeType":"application/vnd.ekstep.content-collection","children":[{"identifier":"$unitId","mimeType":"application/vnd.ekstep.content-collection","children":[{"identifier":"$leaf1Id","mimeType":"application/pdf"},{"identifier":"$leaf2Id","mimeType":"application/pdf","relationalMetadata":{"optional":"true"}}]}]}"""
+    cassandraUtil.upsert(s"INSERT INTO ${jobConfig.hierarchyKeyspaceName}.${jobConfig.hierarchyTableName}(identifier, hierarchy) VALUES ('$rootId', '$hierarchyJson');")
+
+    val redisConnect = new RedisConnect(jobConfig)
+    val dataCache = new DataCache(jobConfig, redisConnect, jobConfig.hierarchyRelationsDbId, List())
+    dataCache.init()
+    val jedis = redisConnect.getConnection(jobConfig.hierarchyRelationsDbId)
+    try {
+      val obj = new ObjectData(rootId, Map("identifier" -> rootId), Some(Map.empty[String, AnyRef]))
+      new TestCollectionPublisher().updateHierarchyRelationships(obj, dataCache)(cassandraUtil, jobConfig)
+
+      jedis.smembers(s"$rootId:$rootId:leafnodes").asScala should contain theSameElementsAs List(leaf1Id, leaf2Id)
+      jedis.smembers(s"$rootId:$unitId:leafnodes").asScala should contain theSameElementsAs List(leaf1Id, leaf2Id)
+      jedis.smembers(s"$rootId:$rootId:optionalnodes").asScala should contain theSameElementsAs List(leaf2Id)
+      jedis.smembers(s"$rootId:$unitId:optionalnodes").asScala should contain theSameElementsAs List(leaf2Id)
+      jedis.smembers(s"$rootId:$leaf1Id:ancestors").asScala should contain theSameElementsAs List(unitId, rootId)
+      jedis.smembers(s"$rootId:$leaf2Id:ancestors").asScala should contain theSameElementsAs List(unitId, rootId)
+    } finally {
+      jedis.close()
+      dataCache.close()
+    }
+  }
+
 }
-class TestCollectionPublisher extends CollectionPublisher {}
+class TestCollectionPublisher extends CollectionPublisher {
+  def testStoreRelationshipData(rootId: String, relationshipType: String, dataMap: Map[String, List[String]], dataCache: DataCache)
+                                (implicit cassandraUtil: CassandraUtil, config: KnowlgPublishConfig): Unit =
+    storeRelationshipData(rootId, relationshipType, dataMap, dataCache)
+}


### PR DESCRIPTION
Store collection hierarchy relationship data (leaf nodes, optional nodes, ancestors) in Redis instead of Yugabyte when Redis is enabled, so a companion change in `lern-service` can read the same keys instead of hitting Yugabyte's `hierarchy_relations` table directly.

`CollectionPublisher.storeRelationshipData` now branches on `config.redisEnabled`: writes `SET "${rootId}:${identifier}:${relationshipType}" <json-array-of-node_ids>` to a dedicated Redis db index (10, `redis.database.hierarchyRelations.id`) via a new `DataCache` wired in `CollectionPublishFunction`, falling back to the existing Cassandra upsert when Redis is disabled. No behavior change when `redis.enabled=false` (default).

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules